### PR TITLE
Include 'requests' in project requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ python setup.py install
 - geopy >= 1.18.1
 - xarray >= 0.10.7
 - networkx >= 2.0.0
+- requests>=2.22.0
 
 To fully leverage tropycal's plotting capabilities, it is strongly recommended to have cartopy >= 0.17.0 installed.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python setup.py install
 - geopy >= 1.18.1
 - xarray >= 0.10.7
 - networkx >= 2.0.0
-- requests>=2.22.0
+- requests >=2.22.0
 
 To fully leverage tropycal's plotting capabilities, it is strongly recommended to have cartopy >= 0.17.0 installed.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python setup.py install
 - geopy >= 1.18.1
 - xarray >= 0.10.7
 - networkx >= 2.0.0
-- requests >=2.22.0
+- requests >= 2.22.0
 
 To fully leverage tropycal's plotting capabilities, it is strongly recommended to have cartopy >= 0.17.0 installed.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     pandas>=0.23.0
     geopy>=1.18.1
     networkx>=2.0.0
+    requests>=2.22.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Add `requests` to `setup.cfg` to resolve the following error:
```
>>> from tropycal import tracks
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/zastari/venv/tropycal/lib/python3.7/site-packages/tropycal/tracks/__init__.py", line 3, in <module>
    from .dataset import TrackDataset
  File "/Users/zastari/venv/tropycal/lib/python3.7/site-packages/tropycal/tracks/dataset.py", line 13, in <module>
    from .plot import TrackPlot
  File "/Users/zastari/venv/tropycal/lib/python3.7/site-packages/tropycal/tracks/plot.py", line 13, in <module>
    from .tools import *
  File "/Users/zastari/venv/tropycal/lib/python3.7/site-packages/tropycal/tracks/tools.py", line 5, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```