### PR TITLE
Fix typo in dataset.py

### DIFF
--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -1389,7 +1389,7 @@ class TrackDataset:
         if save_path == None:
             plt.show()
         else:
-            plt.savefig(savepath,bbox_inches='tight')
+            plt.savefig(save_path,bbox_inches='tight')
         plt.close()
         
         if return_dict == True:
@@ -1700,7 +1700,7 @@ class TrackDataset:
         if save_path == None:
             plt.show()
         else:
-            plt.savefig(savepath,bbox_inches='tight')
+            plt.savefig(save_path,bbox_inches='tight')
         plt.close()
         
         if return_dict == True:


### PR DESCRIPTION
To fix the `NameError` when saving figure in `ace_climo` and `hurricane_days_climo` function
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\27455\AppData\Local\Programs\Python\Python37\lib\site-packages\tropycal\tracks\dataset.py", line 1392, in ace_climo
    plt.savefig(savepath,bbox_inches='tight')
NameError: name 'savepath' is not defined
```