### PR TITLE
Bug fixes and new features

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,6 +11,21 @@ API Reference
    tropycal.tracks
    tropycal.tornado
    tropycal.recon
+   
+###############
+Keyword Options
+###############
+
+.. currentmodule:: tropycal
+
+List of keyword options for various functions in Tropycal:
+
+.. toctree::
+   :maxdepth: 1
+
+   options/domain
+   options/map_prop
+   options/gridded_stats
 
 * :ref:`modindex`
 * :ref:`genindex`

--- a/docs/options/domain.rst
+++ b/docs/options/domain.rst
@@ -1,0 +1,6 @@
+##################
+Map Domain Options
+##################
+
+Coming soon.
+

--- a/docs/options/gridded_stats.rst
+++ b/docs/options/gridded_stats.rst
@@ -1,0 +1,6 @@
+#####################
+Gridded Stats Options
+#####################
+
+Coming soon.
+

--- a/docs/options/map_prop.rst
+++ b/docs/options/map_prop.rst
@@ -1,0 +1,97 @@
+####################
+Map Plotting Options
+####################
+
+Various plotting functions in Tropycal make use of additional properties in the keyword arguments 
+
+Map prop
+========
+
+The following table lists keys that can be passed to the "map_prop" argument as a dictionary.
+
+.. list-table:: Title
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Property
+     - Description
+   * - figsize
+     - Figure size in inches, horizontal by vertical. Default is (14,9).
+   * - dpi
+     - Figure resolutions in pixels per inch. Default is 200.
+   * - res
+     - Resolution of political and geographic boundaries. Options are 'l', 'm', 'h'. Default is 'm'.
+   * - linewidth
+     - Line width for political and geographic boundaries. Default is 0.5.
+   * - linecolor
+     - Line color for political and geographic boundaries. Default is black.
+   * - land_color
+     - Color used to fill land. Default is '#FBF5EA'.
+   * - ocean_color
+     - Color used to fill oceans and lakes. Default is '#EDFBFF'.
+
+Prop
+====
+
+Generic prop options
+--------------------
+
+The following table lists keys that can be passed to the "prop" argument as a dictionary.
+
+.. list-table:: Title
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Property
+     - Description
+   * - dots
+     - Boolean whether to plot storm track dots along the storm track. Default is False.
+   * - fillcolor
+     - Fill color for storm track dots. If 'category', then uses a color scale varying by category.
+   * - linecolor
+     - Line color for storm track. If 'category', then uses a color scale varying by category.
+   * - category_colors
+     - Color scale to use for categories. Default is 'default'. Currently no other option is available.
+   * - linewidth
+     - Line width for storm track. Default varies by function.
+   * - ms
+     - Size of storm track dots. Default is 7.5.
+
+plot_nhc_forecast
+-----------------
+
+The following properties are available only for the ``plot_nhc_forecast()`` function.
+
+.. list-table:: Title
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Property
+     - Description
+   * - cone_lw
+     - Line width for the cone of uncertainty. Default is 1.0.
+   * - cone_alpha
+     - Transparency for the cone of uncertainty. Default is 0.6.
+
+gridded_stats
+-------------
+
+The following properties are available only for the ``gridded_stats()`` function.
+
+.. list-table:: Title
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Property
+     - Description
+   * - cmap
+     - Colormap to use for the plot. If string 'category' is passed (default), uses a pre-defined color scale corresponding to the Saffir-Simpson Hurricane Wind Scale.
+   * - clevs
+     - Contour levels for the plot. Default is minimum and maximum values in the grid.
+   * - left_title
+     - Title string for the left side of the plot. Default is the string passed via the 'request' keyword argument.
+   * - right_title
+     - Title string for the right side of the plot. Default is 'All storms'.
+
+More coming soon.
+

--- a/examples/tracks.TrackDataset.py
+++ b/examples/tracks.TrackDataset.py
@@ -83,11 +83,11 @@ hurdat_atl.wind_pres_relationship(storm=('sandy',2012))
 # 
 # Let's construct a 1 degree grid and plot the maximum sustained wind recorded at each gridpoint:
 
-hurdat_atl.gridded_stats(cmd_request="maximum wind",return_ax=True)
+hurdat_atl.gridded_stats(request="maximum wind",return_ax=True)
 
 # Let's look at the average change in sustained wind speed over a 24-hour period. By default, the value plotted is for the midpoint of the 24-hour period (so 12 hours preceding and following). We'll use the "prop" keyword argument to set the colormap to "bwr" and set the contour level range:
 
-hurdat_atl.gridded_stats(cmd_request="average wind change in 24 hours",prop={'cmap':'bwr','clevs':[-80,80]},return_ax=True)
+hurdat_atl.gridded_stats(request="average wind change in 24 hours",prop={'cmap':'bwr','clevs':[-80,80]},return_ax=True)
 
 ###########################################
 # IBTrACS Dataset
@@ -108,14 +108,14 @@ ibtracs = tracks.TrackDataset(basin='all',source='ibtracs',ibtracs_mode='jtwc_ne
 # 
 # Let's make a plot of the maximum sustained wind of TCs globally:
 
-ibtracs.gridded_stats(cmd_request="maximum wind",return_ax=True)
+ibtracs.gridded_stats(request="maximum wind",return_ax=True)
 
 ###########################################
 # Make a plot of the total number of storms per 1 degree gridbox worldwide:
 
-ibtracs.gridded_stats(cmd_request="count of storms",prop={'cmap':'plasma_r'})
+ibtracs.gridded_stats(request="number of storms",prop={'cmap':'plasma_r'})
 
 ###########################################
 # Make a plot of the total number of rapidly intensifying storms (>=30 kt over 24 hours) per 1 degree gridbox:
 
-ibtracs.gridded_stats(cmd_request="count of storms",thresh={'dV_min':30},prop={'cmap':'plasma_r'})
+ibtracs.gridded_stats(request="number of storms",thresh={'dv_min':30},prop={'cmap':'plasma_r'})

--- a/examples/tracks.tornado.py
+++ b/examples/tracks.tornado.py
@@ -21,7 +21,7 @@ tor_data = tornado.TornadoDataset()
 ###########################################
 # We can use a TornadoDataset object to analyze both tornadoes associated with tropical cyclones and non-TC tornadoes. As an example of the latter, we can make a plot of all tornadoes during the 27 April 2011 tornado outbreak, along with the Practically Perfect Forecast (PPF) in filled contours:
 
-tor_ax,zoom,leg_tor = tor_data.plot_tors(dt.datetime(2011,4,27),plotPPF=True,return_ax=True)
+tor_ax,domain,leg_tor = tor_data.plot_tors(dt.datetime(2011,4,27),plotPPF=True,return_ax=True)
 tor_ax
 
 ###########################################

--- a/src/tropycal/plot/plot.py
+++ b/src/tropycal/plot/plot.py
@@ -297,86 +297,106 @@ class Plot:
         #Return prop
         return default_prop
     
-    def set_projection(self,zoom):
+    def set_projection(self,domain):
         
         r"""
-        Sets a predefined map projection zoom.
+        Sets a predefined map projection domain.
         
         Parameters
         ----------
-        zoom : str
-            Name of map projection to zoom over.
+        domain : str
+            Name of map projection to domain over.
         """
         
         #North Atlantic plot domain
-        if zoom == "north_atlantic":
+        if domain == "north_atlantic":
             bound_w = -105.0
             bound_e = -5.0
             bound_s = 0.0
             bound_n = 65.0
             
         #East Pacific plot domain
-        elif zoom == "east_pacific":
+        elif domain == "east_pacific":
             bound_w = -180.0+360.0 
             bound_e = -80+360.0 
             bound_s = 0.0
             bound_n = 65.0
             
         #West Pacific plot domain
-        elif zoom == "west_pacific":
+        elif domain == "west_pacific":
             bound_w = 90.0
             bound_e = 180.0
             bound_s = 0.0
             bound_n = 65.0
             
         #North Indian plot domain
-        elif zoom == "north_indian":
+        elif domain == "north_indian":
             bound_w = 30.0
             bound_e = 110.0
             bound_s = -5.0
             bound_n = 40.0
             
         #South Indian plot domain
-        elif zoom == "south_indian":
+        elif domain == "south_indian":
             bound_w = 20.0
             bound_e = 110.0
             bound_s = -50.0
             bound_n = 5.0
             
         #Australia plot domain
-        elif zoom == "australia":
+        elif domain == "australia":
             bound_w = 90.0
             bound_e = 180.0
             bound_s = -60.0
             bound_n = 0.0
             
         #South Pacific plot domain
-        elif zoom == "south_pacific":
+        elif domain == "south_pacific":
             bound_w = 140.0
             bound_e = -120.0+360.0
             bound_s = -65.0
             bound_n = 0.0
             
         #Global plot domain
-        elif zoom == "all":
+        elif domain == "all":
             bound_w = 0.1
             bound_e = 360.0
             bound_s = -90.0
             bound_n = 90.0
             
         #CONUS plot domain
-        elif zoom == "conus":
+        elif domain == "conus":
             bound_w = -130.0
             bound_e = -65.0
             bound_s = 20.0
             bound_n = 50.0
 
         #CONUS plot domain
-        elif zoom == "east_conus":
+        elif domain == "east_conus":
             bound_w = -105.0
             bound_e = -60.0
             bound_s = 20.0
             bound_n = 48.0
+        
+        #Custom domain
+        else:
+            
+            #Error check
+            if isinstance(domain,dict) == False:
+                msg = "Custom domains must be of type dict."
+                raise TypeError(msg)
+            
+            keys = domain.keys()
+            check = [False, False, False, False]
+            values = [0, 0, 0, 0]
+            for key in keys:
+                if key[0].lower() == 'n': check[0] = True; bound_n = domain[key]
+                if key[0].lower() == 's': check[1] = True; bound_s = domain[key]
+                if key[0].lower() == 'e': check[2] = True; bound_e = domain[key]
+                if key[0].lower() == 'w': check[3] = True; bound_w = domain[key]
+            if False in check:
+                msg = "Custom domains must be of type dict with arguments for 'n', 's', 'e' and 'w'."
+                raise ValueError(msg)
             
         #Set map extent
         self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
@@ -389,8 +409,9 @@ class Plot:
     
     def add_credit(self,text):
         
-        a = self.ax.text(0.99,0.01,text,fontsize=10,color='k',alpha=0.7,fontweight='bold',
-                transform=self.ax.transAxes,ha='right',va='bottom',zorder=10)
-        a.set_path_effects([path_effects.Stroke(linewidth=5, foreground='white'),
-                       path_effects.Normal()])
+        if self.use_credit:
+            a = self.ax.text(0.99,0.01,text,fontsize=10,color='k',alpha=0.7,fontweight='bold',
+                    transform=self.ax.transAxes,ha='right',va='bottom',zorder=10)
+            a.set_path_effects([path_effects.Stroke(linewidth=5, foreground='white'),
+                           path_effects.Normal()])
         

--- a/src/tropycal/recon/dataset.py
+++ b/src/tropycal/recon/dataset.py
@@ -46,7 +46,6 @@ class ReconDataset:
             indicating the distance (km) of the ob from the interpolated center of the storm.
     """
 
-    #init class
     def __init__(self,storm,save_path="",read_path=""):
         
         if save_path != "" and read_path != "":
@@ -278,7 +277,7 @@ class ReconDataset:
 
     #PLOT FUNCTION FOR RECON POINTS
     #Passed!
-    def plot_points(self,recon_select=None,varname='wspd',zoom="dynamic",ax=None,return_ax=False,cartopy_proj=None,**kwargs):
+    def plot_points(self,recon_select=None,varname='wspd',domain="dynamic",ax=None,return_ax=False,cartopy_proj=None,**kwargs):
         
         r"""
         Creates a plot of recon data points.
@@ -295,13 +294,15 @@ class ReconDataset:
             "wspd" - 30-second flight level wind 
             "pkwnd" - 10-second flight level wind
             "p_sfc" - extrapolated surface pressure
-        zoom : str
-            Zoom for the plot. Can be one of the following:
+        domain : str
+            Domain for the plot. Can be one of the following:
             "dynamic" - default - dynamically focuses the domain using the tornado track(s) plotted, 
             "north_atlantic" - North Atlantic Ocean basin, 
             "lonW/lonE/latS/latN" - Custom plot domain.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
+        return_ax : bool
+            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
             
@@ -339,7 +340,7 @@ class ReconDataset:
             cartopy_proj = self.plot_obj.proj
         
         #Plot recon
-        plot_info = self.plot_obj.plot_points(self.storm_obj,dfRecon,zoom,varname=varname,\
+        plot_info = self.plot_obj.plot_points(self.storm_obj,dfRecon,domain,varname=varname,\
                                               ax=ax,return_ax=return_ax,prop=prop,map_prop=map_prop)
         
         #Return axis
@@ -353,7 +354,7 @@ class ReconDataset:
                        ax=None,return_ax=False,**kwargs):
         
         r"""
-        Creates a hovmoller of azimuthally-averaged recon data.
+        Creates a hovmoller plot of azimuthally-averaged recon data.
         
         Parameters
         ----------
@@ -364,6 +365,8 @@ class ReconDataset:
             String
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
+        return_ax : bool
+            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
             
@@ -433,7 +436,7 @@ class ReconDataset:
 
 
     #PLOT FUNCTION FOR RECON MAPS
-    def plot_maps(self,recon_select=None,varname='wspd',track_dict=None,recon_stats=None,zoom="dynamic",\
+    def plot_maps(self,recon_select=None,varname='wspd',track_dict=None,recon_stats=None,domain="dynamic",\
                   ax=None,return_ax=False,savetopath=None,cartopy_proj=None,**kwargs):
     
         #plot_time, plot_mission (only for dots)
@@ -453,13 +456,15 @@ class ReconDataset:
             "wspd" - 30-second flight level wind 
             "pkwnd" - 10-second flight level wind
             "p_sfc" - extrapolated surface pressure
-        zoom : str
-            Zoom for the plot. Can be one of the following:
+        domain : str
+            Domain for the plot. Can be one of the following:
             "dynamic" - default - dynamically focuses the domain around , 
             "north_atlantic" - North Atlantic Ocean basin, 
             "lonW/lonE/latS/latN" - Custom plot domain.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
+        return_ax : bool
+            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
             
@@ -534,7 +539,7 @@ class ReconDataset:
                 
                 #Plot recon
                 plot_info = self.plot_obj.plot_maps(self.storm_obj,Maps_sub,varname,recon_stats,\
-                                                    zoom,ax,return_ax=True,prop=prop,map_prop=map_prop)
+                                                    domain,ax,return_ax=True,prop=prop,map_prop=map_prop)
                 
                 figs.append(plot_info)
                 
@@ -557,7 +562,7 @@ class ReconDataset:
             
             #Plot recon
             plot_info = self.plot_obj.plot_maps(self.storm_obj,Maps,varname,recon_stats,\
-                                                zoom,ax,return_ax,prop=prop,map_prop=map_prop)
+                                                domain,ax,return_ax,prop=prop,map_prop=map_prop)
             
             #Return axis
             if ax is not None or return_ax:
@@ -567,7 +572,7 @@ class ReconDataset:
     
     #PLOT FUNCTION FOR RECON SWATH
     def plot_swath(self,recon_select=None,varname='wspd',swathfunc=None,track_dict=None,radlim=None,\
-                   zoom="dynamic",ax=None,return_ax=False,cartopy_proj=None,**kwargs):
+                   domain="dynamic",ax=None,return_ax=False,cartopy_proj=None,**kwargs):
         
         r"""
         Creates a map plot of a swath of interpolated recon data.
@@ -586,14 +591,16 @@ class ReconDataset:
             "p_sfc" - extrapolated surface pressure
         swathfunc : function
             Function to operate on interpolated recon data.
-            e.g. np.max, np.min, or percentile function
-        zoom : str
-            Zoom for the plot. Can be one of the following:
+            e.g., np.max, np.min, or percentile function
+        domain : str
+            Domain for the plot. Can be one of the following:
             "dynamic" - default - dynamically focuses the domain using the tornado track(s) plotted, 
             "north_atlantic" - North Atlantic Ocean basin, 
             "lonW/lonE/latS/latN" - Custom plot domain.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
+        return_ax : bool
+            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
             
@@ -610,7 +617,6 @@ class ReconDataset:
         map_prop = kwargs.pop('map_prop',{})
         
         #Get plot data
-
         if recon_select is None:
             dfRecon = self.recentered        
         elif isinstance(recon_select,pd.core.frame.DataFrame):
@@ -644,9 +650,8 @@ class ReconDataset:
         
         #Plot recon
         plot_info = self.plot_obj.plot_swath(self.storm_obj,Maps,varname,swathfunc,track_dict,radlim,\
-                                             zoom,ax,return_ax,prop=prop,map_prop=map_prop)
-    
-    
+                                             domain,ax,return_ax,prop=prop,map_prop=map_prop)
+        
         #Return axis
         if ax != None or return_ax==True:
             return plot_info

--- a/src/tropycal/tornado/dataset.py
+++ b/src/tropycal/tornado/dataset.py
@@ -269,7 +269,7 @@ class TornadoDataset():
             plt.close()
         
 
-    def plot_tors(self,tor_info,zoom="conus",plotPPF=False,ax=None,return_ax=False,cartopy_proj=None,**kwargs):
+    def plot_tors(self,tor_info,domain="conus",plotPPF=False,ax=None,return_ax=False,cartopy_proj=None,**kwargs):
         
         r"""
         Creates a plot of tornado tracks and Practically Perfect Forecast (PPF).
@@ -283,8 +283,8 @@ class TornadoDataset():
             * **dict** entry containing the requested tornadoes to plot.
             * **datetime.datetime** object for a single day to plot tornadoes.
             * **list** with 2 datetime.datetime entries, a start date and end date for plotting over a range of dates.
-        zoom : str
-            Zoom for the plot. Can be one of the following:
+        domain : str
+            Domain for the plot. Can be one of the following:
             
             * **dynamic** - default. Dynamically focuses the domain using the tornado track(s) plotted.
             * **conus** - Contiguous United States
@@ -351,7 +351,7 @@ class TornadoDataset():
             cartopy_proj = self.plot_obj.proj
         
         #Plot tornadoes
-        plot_info = self.plot_obj.plot_tornadoes(dfTors,zoom,plotPPF,ax,return_ax,prop=prop,map_prop=map_prop)
+        plot_info = self.plot_obj.plot_tornadoes(dfTors,domain,plotPPF,ax,return_ax,prop=prop,map_prop=map_prop)
         
         #Return axis
         if ax != None or return_ax==True:

--- a/src/tropycal/tornado/plot.py
+++ b/src/tropycal/tornado/plot.py
@@ -30,8 +30,12 @@ except:
     warnings.warn("Warning: Matplotlib is not installed in your python environment. Plotting functions will not work.")
 
 class TornadoPlot(Plot):
+    
+    def __init__(self):
+        
+        self.use_credit = True
                  
-    def plot_tornadoes(self,tornado,zoom="east_conus",plotPPF=False,ax=None,return_ax=False,prop={},map_prop={}):
+    def plot_tornadoes(self,tornado,domain="east_conus",plotPPF=False,ax=None,return_ax=False,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single storm track.
@@ -40,8 +44,8 @@ class TornadoPlot(Plot):
         ----------
         storm : str, tuple or dict
             Requested storm. Can be either string of storm ID (e.g., "AL052019"), tuple with storm name and year (e.g., ("Matthew",2016)), or a dict entry.
-        zoom : str
-            Zoom for the plot. Can be one of the following:
+        domain : str
+            Domain for the plot. Can be one of the following:
             
             * **dynamic** - default. Dynamically focuses the domain using the tornado track(s) plotted.
             * **north_atlantic** - North Atlantic Ocean basin.
@@ -72,10 +76,6 @@ class TornadoPlot(Plot):
         #set default properties
         input_prop = prop
         input_map_prop = map_prop
-        
-        #error check
-        if isinstance(zoom,str) == False:
-            raise TypeError('Error: zoom must be of type str')
         
         #--------------------------------------------------------------------------------------
         
@@ -141,32 +141,15 @@ class TornadoPlot(Plot):
 
         #--------------------------------------------------------------------------------------
         
-        #Pre-generated zooms
-        if zoom in ['north_atlantic','conus','east_conus']:
-            bound_w,bound_e,bound_s,bound_n = self.set_projection(zoom)
-            
         #Storm-centered plot domain
-        elif zoom == "dynamic":
+        if domain == "dynamic":
             
             bound_w,bound_e,bound_s,bound_n = self.dynamic_map_extent(min_lon,max_lon,min_lat,max_lat)
             self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
             
-        #Custom plot domain
+        #Pre-generated or custom domain
         else:
-            
-            #Check to ensure 3 slashes are provided
-            if zoom.count("/") != 3:
-                raise ValueError("Error: Custom map projection bounds must be provided as 'west/east/south/north'")
-            else:
-                try:
-                    bound_w,bound_e,bound_s,bound_n = zoom.split("/")
-                    bound_w = float(bound_w)
-                    bound_e = float(bound_e)
-                    bound_s = float(bound_s)
-                    bound_n = float(bound_n)
-                    self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
-                except:
-                    raise ValueError("Error: Custom map projection bounds must be provided as 'west/east/south/north'")
+            bound_w,bound_e,bound_s,bound_n = self.set_projection(domain)
         
         #Determine number of lat/lon lines to use for parallels & meridians
         self.plot_lat_lon_lines([bound_w,bound_e,bound_s,bound_n])

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -1437,10 +1437,10 @@ class TrackPlot(Plot):
         
         else:
             print('--> Generating plot')
-            if varname=='date' and prop['smooth'] is not None:
-                zcoord[np.isnan(zcoord)]=0
-                zcoord=gfilt(zcoord,sigma=prop['smooth'])
-                zcoord[zcoord<min(clevs)]=np.nan
+            #if varname=='date' and prop['smooth'] is not None:
+            #    zcoord[np.isnan(zcoord)]=0
+            #    zcoord=gfilt(zcoord,sigma=prop['smooth'])
+            #    zcoord[zcoord<min(clevs)]=np.nan
             cbmap = self.ax.pcolor(xcoord,ycoord,zcoord,cmap=cmap,vmin=min(clevs),vmax=max(clevs),
                            transform=ccrs.PlateCarree())
 

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -33,7 +33,11 @@ except:
 
 class TrackPlot(Plot):
     
-    def plot_storm(self,storm,zoom="dynamic",plot_all=False,ax=None,return_ax=False,track_labels=False,prop={},map_prop={}):
+    def __init__(self):
+        
+        self.use_credit = True
+    
+    def plot_storm(self,storm,domain="dynamic",plot_all=False,ax=None,return_ax=False,track_labels=False,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single storm track.
@@ -42,8 +46,8 @@ class TrackPlot(Plot):
         ----------
         storm : str, tuple or dict
             Requested storm. Can be either string of storm ID (e.g., "AL052019"), tuple with storm name and year (e.g., ("Matthew",2016)), or a dict entry.
-        zoom : str
-            Zoom for the plot. Can be one of the following:
+        domain : str
+            Domain for the plot. Can be one of the following:
             "dynamic" - default. Dynamically focuses the domain using the storm track(s) plotted.
             "north_atlantic" - North Atlantic Ocean basin
             "pacific" - East/Central Pacific Ocean basin
@@ -68,10 +72,6 @@ class TrackPlot(Plot):
         prop = self.add_prop(prop,default_prop)
         map_prop = self.add_prop(map_prop,default_map_prop)
         self.plot_init(ax,map_prop)
-        
-        #error check
-        if isinstance(zoom,str) == False:
-            raise TypeError('Error: zoom must be of type str')
         
         #--------------------------------------------------------------------------------------
         
@@ -175,33 +175,16 @@ class TrackPlot(Plot):
         #--------------------------------------------------------------------------------------
 
         
-        #Pre-generated zooms
-        if zoom in ['north_atlantic','east_pacific','west_pacific','south_pacific','south_indian','north_indian','australia','all']:
-            bound_w,bound_e,bound_s,bound_n = self.set_projection(zoom)
-            
         #Storm-centered plot domain
-        elif zoom == "dynamic":
+        if domain == "dynamic":
             
             bound_w,bound_e,bound_s,bound_n = self.dynamic_map_extent(min_lon,max_lon,min_lat,max_lat)
             self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
             
-        #Custom plot domain
+        #Pre-generated or custom domain
         else:
-            
-            #Check to ensure 3 slashes are provided
-            if zoom.count("/") != 3:
-                raise ValueError("Error: Custom map projection bounds must be provided as 'west/east/south/north'")
-            else:
-                try:
-                    bound_w,bound_e,bound_s,bound_n = zoom.split("/")
-                    bound_w = float(bound_w)
-                    bound_e = float(bound_e)
-                    bound_s = float(bound_s)
-                    bound_n = float(bound_n)
-                    self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
-                except:
-                    raise ValueError("Error: Custom map projection bounds must be provided as 'west/east/south/north'")
-        
+            bound_w,bound_e,bound_s,bound_n = self.set_projection(domain)
+
         #Plot parallels and meridians
         #This is currently not supported for all cartopy projections.
         try:
@@ -277,7 +260,7 @@ class TrackPlot(Plot):
             plt.show()
             plt.close()
     
-    def plot_storms(self,storms,zoom="dynamic",title_text="TC Track Composite",filter_dates=('1/1','12/31'),plot_all_dots=False,ax=None,return_ax=False,prop={},map_prop={}):
+    def plot_storms(self,storms,domain="dynamic",title_text="TC Track Composite",filter_dates=('1/1','12/31'),plot_all_dots=False,ax=None,return_ax=False,prop={},map_prop={}):
         
         r"""
         Creates a plot of multiple storm tracks.
@@ -286,8 +269,8 @@ class TrackPlot(Plot):
         ----------
         storms : list
             List of requested storms. List can contain either strings of storm ID (e.g., "AL052019"), tuples with storm name and year (e.g., ("Matthew",2016)), or dict entries.
-        zoom : str
-            Zoom for the plot. Can be one of the following:
+        domain : str
+            Domain for the plot. Can be one of the following:
             "dynamic" - default. Dynamically focuses the domain using the storm track(s) plotted.
             "north_atlantic" - North Atlantic Ocean basin
             "pacific" - East/Central Pacific Ocean basin
@@ -312,10 +295,6 @@ class TrackPlot(Plot):
         prop = self.add_prop(prop,default_prop)
         map_prop = self.add_prop(map_prop,default_map_prop)
         self.plot_init(ax,map_prop)
-        
-        #error check
-        if isinstance(zoom,str) == False:
-            raise TypeError('Error: zoom must be of type str')
         
         #--------------------------------------------------------------------------------------
         
@@ -413,32 +392,15 @@ class TrackPlot(Plot):
         #--------------------------------------------------------------------------------------
         
         
-        #Pre-generated zooms
-        if zoom in ['north_atlantic','east_pacific','west_pacific','south_pacific','south_indian','north_indian','australia','all']:
-            bound_w,bound_e,bound_s,bound_n = self.set_projection(zoom)
-            
         #Storm-centered plot domain
-        elif zoom == "dynamic":
+        if domain == "dynamic":
             
             bound_w,bound_e,bound_s,bound_n = self.dynamic_map_extent(min_lon,max_lon,min_lat,max_lat)
             self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
             
-        #Custom plot domain
+        #Pre-generated or custom domain
         else:
-            
-            #Check to ensure 3 slashes are provided
-            if zoom.count("/") != 3:
-                raise ValueError("Error: Custom map projection bounds must be provided as 'west/east/south/north'")
-            else:
-                try:
-                    bound_w,bound_e,bound_s,bound_n = zoom.split("/")
-                    bound_w = float(bound_w)
-                    bound_e = float(bound_e)
-                    bound_s = float(bound_s)
-                    bound_n = float(bound_n)
-                    self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
-                except:
-                    raise ValueError("Error: Custom map projection bounds must be provided as 'west/east/south/north'")
+            bound_w,bound_e,bound_s,bound_n = self.set_projection(domain)
         
         #Plot parallels and meridians
         #This is currently not supported for all cartopy projections.
@@ -485,7 +447,7 @@ class TrackPlot(Plot):
             plt.show()
             plt.close()
         
-    def plot_storm_nhc(self,forecast,track=None,track_labels='fhr',cone_days=5,zoom="dynamic_forecast",ax=None,return_ax=False,prop={},map_prop={}):
+    def plot_storm_nhc(self,forecast,track=None,track_labels='fhr',cone_days=5,domain="dynamic_forecast",ax=None,return_ax=False,prop={},map_prop={}):
         
         r"""
         Creates a plot of the operational NHC forecast track along with observed track data.
@@ -504,8 +466,8 @@ class TrackPlot(Plot):
             'valid_edt' = EDT valid time
         cone_days : int
             Number of days to plot the forecast cone. Default is 5 days. Can select 2, 3, 4 or 5 days.
-        zoom : str
-            Zoom for the plot. Can be one of the following:
+        domain : str
+            Domain for the plot. Can be one of the following:
             "dynamic_forecast" - default. Dynamically focuses the domain on the forecast track.
             "dynamic" - Dynamically focuses the domain on the combined observed and forecast track.
             "lonW/lonE/latS/latN" - Custom plot domain
@@ -591,7 +553,7 @@ class TrackPlot(Plot):
                 sdate.append(sdate[-1]+timedelta(hours=start_slice))
 
                 #Add to coordinate extrema
-                if zoom != "dynamic_forecast":
+                if domain != "dynamic_forecast":
                     if max_lat == None:
                         max_lat = max(lats)
                     else:
@@ -743,7 +705,7 @@ class TrackPlot(Plot):
                 self.plot_nhc_labels(self.ax, fcst_lon, fcst_lat, labels, k=1.2)
                 
             #Add cone coordinates to coordinate extrema
-            if zoom == "dynamic_forecast" or max_lat == None:
+            if domain == "dynamic_forecast" or max_lat == None:
                 max_lat = max(cone_lat)
                 min_lat = min(cone_lat)
                 max_lon = max(cone_lon)
@@ -756,33 +718,15 @@ class TrackPlot(Plot):
 
         #--------------------------------------------------------------------------------------
 
-        #Pre-generated zooms
-        if zoom in ['north_atlantic','east_pacific','west_pacific','south_pacific','south_indian','north_indian','australia','all']:
-            bound_w,bound_e,bound_s,bound_n = self.set_projection(zoom)
-
         #Storm-centered plot domain
-        elif zoom == "dynamic" or zoom == 'dynamic_forecast':
+        if domain == "dynamic" or domain == 'dynamic_forecast':
             
             bound_w,bound_e,bound_s,bound_n = self.dynamic_map_extent(min_lon,max_lon,min_lat,max_lat)
-
             self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
             
-        #Custom plot domain
+        #Pre-generated or custom domain
         else:
-            
-            #Check to ensure 3 slashes are provided
-            if zoom.count("/") != 3:
-                raise ValueError("Error: Custom map projection bounds must be provided as 'west/east/south/north'")
-            else:
-                try:
-                    bound_w,bound_e,bound_s,bound_n = zoom.split("/")
-                    bound_w = float(bound_w)
-                    bound_e = float(bound_e)
-                    bound_s = float(bound_s)
-                    bound_n = float(bound_n)
-                    self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
-                except:
-                    raise ValueError("Error: Custom map projection bounds must be provided as 'west/east/south/north'")
+            bound_w,bound_e,bound_s,bound_n = self.set_projection(domain)
         
         #Plot parallels and meridians
         #This is currently not supported for all cartopy projections.
@@ -936,8 +880,8 @@ class TrackPlot(Plot):
         max_lon = None
         min_lon = None
 
-        sinfo = season.annual_summary()
-        storms = sinfo['id']
+        sinfo = season.summary()
+        storms = season.dict.keys()
         for istorm in storms:
 
             #Get data for this storm
@@ -990,7 +934,7 @@ class TrackPlot(Plot):
 
         #--------------------------------------------------------------------------------------
         
-        #Pre-generated zooms
+        #Pre-generated domains
         bound_w,bound_e,bound_s,bound_n = self.set_projection(season.basin)
             
         #Determine number of lat/lon lines to use for parallels & meridians
@@ -1046,7 +990,16 @@ class TrackPlot(Plot):
         #Add right title
         endash = u"\u2013"
         dot = u"\u2022"
-        self.ax.set_title(f"{sinfo['season_named']} named {dot} {sinfo['season_hurricane']} hurricanes {dot} {sinfo['season_major']} major\n{sinfo['season_ace']:.1f} Cumulative ACE",loc='right',fontsize=13)
+        count_named = sinfo['season_named']
+        count_hurricane = sinfo['season_hurricane']
+        count_major = sinfo['season_major']
+        count_ace = sinfo['season_ace']
+        if isinstance(season.year,list) == True:
+            count_named = np.sum(sinfo['season_named'])
+            count_hurricane = np.sum(sinfo['season_hurricane'])
+            count_major = np.sum(sinfo['season_major'])
+            count_ace = np.sum(sinfo['season_ace'])
+        self.ax.set_title(f"{count_named} named {dot} {count_hurricane} hurricanes {dot} {count_major} major\n{count_ace:.1f} Cumulative ACE",loc='right',fontsize=13)
 
         #--------------------------------------------------------------------------------------
 
@@ -1102,6 +1055,7 @@ class TrackPlot(Plot):
         #Radii are in nautical miles
         cone_climo_hr = [3,12,24,36,48,72,96,120]
         cone_size_atl = {}
+        cone_size_atl[2020] = [16,26,41,55,69,103,151,196]
         cone_size_atl[2019] = [16,26,41,54,68,102,151,198]
         cone_size_atl[2018] = [16,26,43,56,74,103,151,198]
         cone_size_atl[2017] = [16,29,45,63,78,107,159,211]
@@ -1116,6 +1070,7 @@ class TrackPlot(Plot):
         cone_size_atl[2008] = [16,39,67,92,118,170,233,305]
 
         cone_size_pac = {}
+        cone_size_pac[2020] = [16,25,38,51,65,91,115,138]
         cone_size_pac[2019] = [16,25,38,48,62,88,115,145]
         cone_size_pac[2018] = [16,25,39,50,66,94,125,162]
         cone_size_pac[2017] = [16,25,40,51,66,93,116,151]
@@ -1129,11 +1084,13 @@ class TrackPlot(Plot):
         cone_size_pac[2009] = [16,36,59,85,105,148,187,230]
         cone_size_pac[2008] = [16,36,66,92,115,161,210,256]
 
+        #Function for interpolating between 2 times
         def temporal_interpolation(value, orig_times, target_times):
             f = interp.interp1d(orig_times,value)
             ynew = f(target_times)
             return ynew
 
+        #Function for plugging small array into larger array
         def plug_array(small,large,small_coords,large_coords):
 
             small_lat = np.round(small_coords['lat'],2)
@@ -1167,10 +1124,11 @@ class TrackPlot(Plot):
 
             return large
 
+        #Function for finding nearest value in an array
         def findNearest(array,val):
             return array[np.abs(array - val).argmin()]
 
-        ###### Plot cyclogenesis location density
+        #Function for adding a radius surrounding a point
         def add_radius(lats,lons,vlat,vlon,rad):
 
             #construct new array expanding slightly over rad from lat/lon center
@@ -1201,9 +1159,8 @@ class TrackPlot(Plot):
             small_coords = {'lat':nlat,'lon':nlon}
 
             return return_arr, small_coords
-
-
-
+        
+        #--------------------------------------------------------------------
 
         #Retrieve cone size for given year
         if forecast['init'].year in cone_size_atl.keys():
@@ -1282,9 +1239,9 @@ class TrackPlot(Plot):
             temp_lon[temp_lon<0] = temp_lon[temp_lon<0]+360.0
             fcst_lon = temp_lon.tolist()
 
-        #Interpolate forecast data temporally
+        #Interpolate forecast data temporally and spatially
         interp_kind = 'quadratic'
-        if len(t) == 2: interp_kind = 'linear'
+        if len(t) == 2: interp_kind = 'linear' #Interpolate linearly if only 2 forecast points
         x1 = interp.interp1d(t,fcst_lon,kind=interp_kind)
         y1 = interp.interp1d(t,fcst_lat,kind=interp_kind)
         interp_fhr = interp_fhr_idx * 6
@@ -1407,7 +1364,7 @@ class TrackPlot(Plot):
                                         color='k'),
                         transform=ccrs.PlateCarree())
 
-    def plot_gridded(self,xcoord,ycoord,zcoord,VEC_FLAG=False,zoom="north_atlantic",ax=None,return_ax=False,prop={},map_prop={}):
+    def plot_gridded(self,xcoord,ycoord,zcoord,VEC_FLAG=False,domain="north_atlantic",ax=None,return_ax=False,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single storm track.
@@ -1416,9 +1373,8 @@ class TrackPlot(Plot):
         ----------
         storm : str, tuple or dict
             Requested storm. Can be either string of storm ID (e.g., "AL052019"), tuple with storm name and year (e.g., ("Matthew",2016)), or a dict entry.
-        zoom : str
-            Zoom for the plot. Can be one of the following:
-            "dynamic" - default. Dynamically focuses the domain using the storm track(s) plotted.
+        domain : str
+            Domain for the plot. Default is TrackDataset basin. Can be one of the following:
             "north_atlantic" - North Atlantic Ocean basin
             "pacific" - East/Central Pacific Ocean basin
             "lonW/lonE/latS/latN" - Custom plot domain
@@ -1435,38 +1391,16 @@ class TrackPlot(Plot):
         """
         
         #Set default properties
-        default_prop={'cmap':'category','clevs':[np.nanmin(zcoord),np.nanmax(zcoord)],'left_title':'','right_title':'All storms','pcolor':True,'smooth':None}
+        default_prop={'cmap':'category','clevs':[np.nanmin(zcoord),np.nanmax(zcoord)],'left_title':'','right_title':'All storms'}
         default_map_prop={'res':'m','land_color':'#FBF5EA','ocean_color':'#EDFBFF','linewidth':0.5,'linecolor':'k','figsize':(14,9),'dpi':200}
         
         #Initialize plot
         prop = self.add_prop(prop,default_prop)
         map_prop = self.add_prop(map_prop,default_map_prop)
         self.plot_init(ax,map_prop)
-        
-        #error check
-        if isinstance(zoom,str) == False:
-            raise TypeError('Error: zoom must be of type str')
-        
-        #Pre-generated zooms
-        if zoom in ['north_atlantic','east_pacific','west_pacific','south_pacific','south_indian','north_indian','australia','all']:
-            bound_w,bound_e,bound_s,bound_n = self.set_projection(zoom)
-            
-        #Custom plot domain
-        else:
-            
-            #Check to ensure 3 slashes are provided
-            if zoom.count("/") != 3:
-                raise ValueError("Error: Custom map projection bounds must be provided as 'west/east/south/north'")
-            else:
-                try:
-                    bound_w,bound_e,bound_s,bound_n = zoom.split("/")
-                    bound_w = float(bound_w)
-                    bound_e = float(bound_e)
-                    bound_s = float(bound_s)
-                    bound_n = float(bound_n)
-                    self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
-                except:
-                    raise ValueError("Error: Custom map projection bounds must be provided as 'west/east/south/north'")
+
+        #Plot domain
+        bound_w,bound_e,bound_s,bound_n = self.set_projection(domain)
         
         #Plot parallels and meridians
         #This is currently not supported for all cartopy projections.
@@ -1502,20 +1436,14 @@ class TrackPlot(Plot):
             zcoord = mag
         
         else:
-            print('doing the plotting')
-            if prop['pcolor']:
-                if varname=='date' and prop['smooth'] is not None:
-                    zcoord[np.isnan(zcoord)]=0
-                    zcoord=gfilt(zcoord,sigma=prop['smooth'])
-                    zcoord[zcoord<min(clevs)]=np.nan
-                cbmap = self.ax.pcolor(xcoord,ycoord,zcoord,cmap=cmap,vmin=min(clevs),vmax=max(clevs),
-                               transform=ccrs.PlateCarree())
-            else:
-                clevs = prop['clevs']
-                cmap = prop['cmap']
-                cbmap = self.ax.contourf(xcoord,ycoord,zcoord,clevs,cmap = cmap,
-                               transform=ccrs.PlateCarree())
-        
+            print('--> Generating plot')
+            if varname=='date' and prop['smooth'] is not None:
+                zcoord[np.isnan(zcoord)]=0
+                zcoord=gfilt(zcoord,sigma=prop['smooth'])
+                zcoord[zcoord<min(clevs)]=np.nan
+            cbmap = self.ax.pcolor(xcoord,ycoord,zcoord,cmap=cmap,vmin=min(clevs),vmax=max(clevs),
+                           transform=ccrs.PlateCarree())
+
         #--------------------------------------------------------------------------------------
 
         
@@ -1534,7 +1462,7 @@ class TrackPlot(Plot):
         cax = self.fig.add_axes([bb.x0+bb.width, bb.y0-.05*bb.height, 0.015, bb.height])
         cbar = self.fig.colorbar(cbmap,cax=cax,orientation='vertical',\
                                  ticks=clevs)
-        if len(clevs)>2 and prop['pcolor']:
+        if len(clevs)>2:
             cbar.ax.yaxis.set_ticks(clevs)
         cbar.ax.tick_params(labelsize=11.5)
         cax.yaxis.set_ticks_position('left')

--- a/src/tropycal/tracks/season.py
+++ b/src/tropycal/tracks/season.py
@@ -10,6 +10,7 @@ import warnings
 from datetime import datetime as dt,timedelta
 
 from .plot import TrackPlot
+from .storm import Storm
 from .tools import *
     
 class Season:
@@ -35,6 +36,49 @@ class Season:
         
     def __getitem__(self, key):
         return self.__dict__[key]
+   
+    def __add__(self, new):
+        #Add seasons
+        
+        #Ensure data sources and basins are the same
+        if self.source_basin != new.source_basin:
+            msg = 'Seasons can only be added for the same basin.'
+            raise ValueError(msg)
+        if self.source != new.source:
+            msg = 'Seasons can only be added from the same source.'
+            raise ValueError(msg)
+        if self.source == 'ibtracs':
+            msg = 'Only hurdat data sources are currently supported for this functionality.'
+            raise RuntimeError(msg)
+        
+        #Retrieve old & new dict entries
+        dict_original = self.dict.copy()
+        dict_new = new.dict.copy()
+        
+        #Retrieve copy of coordinates
+        new_coords = self.coords.copy()
+        
+        #Add year to list of years
+        if isinstance(self.coords['year'],int) == True:
+            new_coords['year'] = [self.year,new.year]
+        else:
+            new_coords['year'].append(new.year)
+        
+        #Sort list of years
+        new_coords['year'] = (np.sort(new_coords['year'])).tolist()
+        
+        #Update dict
+        dict_original.update(dict_new)
+        
+        #Iterate over every year to create a new dict
+        new_dict = {}
+        for year in new_coords['year']:
+            for key in dict_original.keys():
+                if int(key[-4:]) == year:
+                    new_dict[key] = dict_original[key]
+        
+        #Return new Season object
+        return Season(new_dict,new_coords)
     
     def __repr__(self):
          
@@ -42,7 +86,7 @@ class Season:
         summary = ["<tropycal.tracks.Season>"]
         
         #Format keys for summary
-        season_summary = self.annual_summary()
+        season_summary = self.summary()
         summary_keys = {'Total Storms':season_summary['season_storms'],
                         'Named Storms':season_summary['season_named'],
                         'Hurricanes':season_summary['season_hurricane'],
@@ -54,16 +98,18 @@ class Season:
         add_space = np.max([len(key) for key in summary_keys.keys()])+3
         for key in summary_keys.keys():
             key_name = key+":"
-            val = '%0.1f'%(summary_keys[key]) if key == 'Season ACE' else summary_keys[key]
-            summary.append(f'{" "*4}{key_name:<{add_space}}{val}')
+            #val = '%0.1f'%(summary_keys[key]) if key == 'Season ACE' else summary_keys[key]
+            #summary.append(f'{" "*4}{key_name:<{add_space}}{val}')
+            summary.append(f'{" "*4}{key_name:<{add_space}}{summary_keys[key]}')
         
         #Add additional information
         summary.append("\nMore Information:")
         add_space = np.max([len(key) for key in self.coords.keys()])+3
         for key in self.coords.keys():
             key_name = key+":"
-            val = '%0.1f'%(self.coords[key]) if key == 'ace' else self.coords[key]
-            summary.append(f'{" "*4}{key_name:<{add_space}}{val}')
+            #val = '%0.1f'%(self.coords[key]) if key == 'ace' else self.coords[key]
+            #summary.append(f'{" "*4}{key_name:<{add_space}}{val}')
+            summary.append(f'{" "*4}{key_name:<{add_space}}{self.coords[key]}')
 
         return "\n".join(summary)
     
@@ -77,6 +123,9 @@ class Season:
         self.coords = {}
         for key in keys:
             if isinstance(info[key], list) == False and isinstance(info[key], dict) == False:
+                self[key] = info[key]
+                self.coords[key] = info[key]
+            if isinstance(info[key], list) == True and key == 'year':
                 self[key] = info[key]
                 self.coords[key] = info[key]
     
@@ -98,11 +147,11 @@ class Season:
             raise RuntimeError("Error: pandas is not available. Install pandas in order to use this function.") from e
         
         #Get season info
-        season_info = self.annual_summary()
+        season_info = self.summary()
         season_info_keys = season_info['id']
         
         #Set up empty dict for dataframe
-        ds = {'id':[],'name':[],'vmax':[],'mslp':[],'category':[],'ace':[],'start_time':[],'end_time':[]}
+        ds = {'id':[],'name':[],'vmax':[],'mslp':[],'category':[],'ace':[],'start_time':[],'end_time':[],'start_lat':[],'start_lon':[]}
         
         #Add every key containing a list into the dict
         keys = [k for k in self.dict.keys()]
@@ -116,6 +165,8 @@ class Season:
                 ds['category'].append(season_info['category'][sidx])
                 ds['start_time'].append(self.dict[key]['date'][0])
                 ds['end_time'].append(self.dict[key]['date'][-1])
+                ds['start_lat'].append(self.dict[key]['lat'][0])
+                ds['start_lon'].append(self.dict[key]['lon'][0])
                 ds['ace'].append(np.round(season_info['ace'][sidx],1))
                     
         #Convert entire dict to a DataFrame
@@ -123,6 +174,75 @@ class Season:
 
         #Return dataset
         return ds
+    
+    def get_storm_id(self,storm):
+        
+        r"""
+        Returns the storm ID (e.g., "AL012019") given the storm name and year.
+        
+        Parameters
+        ----------
+        storm : tuple
+            Tuple containing the storm name and year (e.g., ("Matthew",2016)).
+            
+        Returns
+        -------
+        str or list
+            If a single storm was found, returns a string containing its ID. Otherwise returns a list of matching IDs.
+        """
+        
+        #Error check
+        if isinstance(storm,tuple) == False:
+            raise TypeError("storm must be of type tuple.")
+        if len(storm) != 2:
+            raise ValueError("storm must contain 2 elements, name (str) and year (int)")
+        name,year = storm
+        
+        #Search for corresponding entry in keys
+        keys_use = []
+        for key in self.dict.keys():
+            temp_year = self.dict[key]['year']
+            if temp_year == year:
+                temp_name = self.dict[key]['name']
+                if temp_name == name.upper():
+                    keys_use.append(key)
+                
+        #return key, or list of keys
+        if len(keys_use) == 1: keys_use = keys_use[0]
+        if len(keys_use) == 0: raise RuntimeError("Storm not found")
+        return keys_use
+    
+    def get_storm(self,storm):
+        
+        r"""
+        Retrieves a Storm object for the requested storm.
+        
+        Parameters
+        ----------
+        storm : str or tuple
+            Requested storm. Can be either string of storm ID (e.g., "AL052019"), or tuple with storm name and year (e.g., ("Matthew",2016)).
+        
+        Returns
+        -------
+        tropycal.tracks.Storm
+            Object containing information about the requested storm, and methods for analyzing and plotting the storm.
+        """
+        
+        #Check if storm is str or tuple
+        if isinstance(storm, str) == True:
+            key = storm
+        elif isinstance(storm, tuple) == True:
+            key = self.get_storm_id((storm[0],storm[1]))
+        else:
+            raise RuntimeError("Storm must be a string (e.g., 'AL052019') or tuple (e.g., ('Matthew',2016)).")
+        
+        #Retrieve key of given storm
+        if isinstance(key, str) == True:
+            return Storm(self.dict[key])
+        else:
+            error_message = ''.join([f"\n{i}" for i in key])
+            error_message = f"Multiple IDs were identified for the requested storm. Choose one of the following storm IDs and provide it as the 'storm' argument instead of a tuple:{error_message}"
+            raise RuntimeError(error_message)
         
     def plot(self,ax=None,return_ax=False,cartopy_proj=None,prop={},map_prop={}):
         
@@ -133,6 +253,8 @@ class Season:
         ----------
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
+        return_ax : bool
+            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         prop : dict
@@ -156,7 +278,7 @@ class Season:
         #Return axis
         if ax != None or return_ax == True: return return_ax
         
-    def annual_summary(self):
+    def summary(self):
         
         r"""
         Generates a summary for this season with various cumulative statistics.
@@ -167,76 +289,141 @@ class Season:
             Dictionary containing various statistics about this season.
         """
         
-        #Initialize dict with info about all of year's storms
-        hurdat_year = {'id':[],'operational_id':[],'name':[],'max_wspd':[],'min_mslp':[],'category':[],'ace':[]}
+        #Determine if season object has a single or multiple seasons
+        multi_season = True if isinstance(self.year,list) == True else False
         
-        #Search for corresponding entry in keys
-        count_ss_pure = 0
-        count_ss_partial = 0
-        iterate_id = 1
-        for key in self.dict.keys():
+        #Initialize dict with info about all of year's storms
+        if multi_season == False:
+            hurdat_year = {'id':[],'operational_id':[],'name':[],'max_wspd':[],'min_mslp':[],'category':[],'ace':[]}
+        else:
+            hurdat_year = {'id':[[] for i in range(len(self.year))],
+                           'operational_id':[[] for i in range(len(self.year))],
+                           'name':[[] for i in range(len(self.year))],
+                           'max_wspd':[[] for i in range(len(self.year))],
+                           'min_mslp':[[] for i in range(len(self.year))],
+                           'category':[[] for i in range(len(self.year))],
+                           'ace':[[] for i in range(len(self.year))],
+                           
+                           'seasons':self.year + [],
+                           'season_start':[0 for i in range(len(self.year))],
+                           'season_end':[0 for i in range(len(self.year))],
+                           'season_storms':[0 for i in range(len(self.year))],
+                           'season_named':[0 for i in range(len(self.year))],
+                           'season_hurricane':[0 for i in range(len(self.year))],
+                           'season_major':[0 for i in range(len(self.year))],
+                           'season_ace':[0 for i in range(len(self.year))],
+                           'season_subtrop_pure':[0 for i in range(len(self.year))],
+                           'season_subtrop_partial':[0 for i in range(len(self.year))],
+                          }
+        
+        #Iterate over season(s)
+        list_seasons = [self.year] if multi_season == False else self.year + []
+        for season_idx,iter_season in enumerate(list_seasons):
 
-            #Retrieve info about storm
-            temp_name = self.dict[key]['name']
-            temp_vmax = np.array(self.dict[key]['vmax'])
-            temp_mslp = np.array(self.dict[key]['mslp'])
-            temp_type = np.array(self.dict[key]['type'])
-            temp_time = np.array(self.dict[key]['date'])
-            temp_ace = self.dict[key]['ace']
+            #Search for corresponding entry in keys
+            count_ss_pure = 0
+            count_ss_partial = 0
+            iterate_id = 1
+            for key in self.dict.keys():
+                
+                #Skip if using multi-season object and storm is outside of this season
+                if multi_season == True and int(key[-4:]) != iter_season: continue
 
-            #Get indices of all tropical/subtropical time steps
-            idx = np.where((temp_type == 'SS') | (temp_type == 'SD') | (temp_type == 'TD') | (temp_type == 'TS') | (temp_type == 'HU'))
+                #Retrieve info about storm
+                temp_name = self.dict[key]['name']
+                temp_vmax = np.array(self.dict[key]['vmax'])
+                temp_mslp = np.array(self.dict[key]['mslp'])
+                temp_type = np.array(self.dict[key]['type'])
+                temp_time = np.array(self.dict[key]['date'])
+                temp_ace = np.round(self.dict[key]['ace'],1)
 
-            #Get times during existence of trop/subtrop storms
-            if len(idx[0]) == 0: continue
-            trop_time = temp_time[idx]
-            if 'season_start' not in hurdat_year.keys():
-                hurdat_year['season_start'] = trop_time[0]
-            hurdat_year['season_end'] = trop_time[-1]
+                #Get indices of all tropical/subtropical time steps
+                idx = np.where((temp_type == 'SS') | (temp_type == 'SD') | (temp_type == 'TD') | (temp_type == 'TS') | (temp_type == 'HU'))
 
-            #Get max/min values and check for nan's
-            np_wnd = np.array(temp_vmax[idx])
-            np_slp = np.array(temp_mslp[idx])
-            if len(np_wnd[~np.isnan(np_wnd)]) == 0:
-                max_wnd = np.nan
-                max_cat = -1
+                #Get times during existence of trop/subtrop storms
+                if len(idx[0]) == 0: continue
+                trop_time = temp_time[idx]
+                
+                if multi_season == False:
+                    if 'season_start' not in hurdat_year.keys():
+                        hurdat_year['season_start'] = trop_time[0]
+                    if 'season_end' not in hurdat_year.keys():
+                        hurdat_year['season_end'] = trop_time[-1]
+                    else:
+                        if trop_time[-1] > hurdat_year['season_end']: hurdat_year['season_end'] = trop_time[-1]
+                else:
+                    if hurdat_year['season_start'][season_idx] == 0:
+                        hurdat_year['season_start'][season_idx] = trop_time[0]
+                    if hurdat_year['season_end'][season_idx] == 0:
+                        hurdat_year['season_end'][season_idx] = trop_time[-1]
+                    else:
+                        if trop_time[-1] > hurdat_year['season_end'][season_idx]: hurdat_year['season_end'][season_idx] = trop_time[-1]
+
+                #Get max/min values and check for nan's
+                np_wnd = np.array(temp_vmax[idx])
+                np_slp = np.array(temp_mslp[idx])
+                if len(np_wnd[~np.isnan(np_wnd)]) == 0:
+                    max_wnd = np.nan
+                    max_cat = -1
+                else:
+                    max_wnd = int(np.nanmax(temp_vmax[idx]))
+                    max_cat = convert_category(np.nanmax(temp_vmax[idx]))
+                if len(np_slp[~np.isnan(np_slp)]) == 0:
+                    min_slp = np.nan
+                else:
+                    min_slp = int(np.nanmin(temp_mslp[idx]))
+
+                #Append to dict
+                if multi_season == False:
+                    hurdat_year['id'].append(key)
+                    hurdat_year['name'].append(temp_name)
+                    hurdat_year['max_wspd'].append(max_wnd)
+                    hurdat_year['min_mslp'].append(min_slp)
+                    hurdat_year['category'].append(max_cat)
+                    hurdat_year['ace'].append(temp_ace)
+                    hurdat_year['operational_id'].append(self.dict[key]['operational_id'])
+                else:
+                    hurdat_year['id'][season_idx].append(key)
+                    hurdat_year['name'][season_idx].append(temp_name)
+                    hurdat_year['max_wspd'][season_idx].append(max_wnd)
+                    hurdat_year['min_mslp'][season_idx].append(min_slp)
+                    hurdat_year['category'][season_idx].append(max_cat)
+                    hurdat_year['ace'][season_idx].append(temp_ace)
+                    hurdat_year['operational_id'][season_idx].append(self.dict[key]['operational_id'])
+
+                #Handle operational vs. non-operational storms
+
+                #Check for purely subtropical storms
+                if 'SS' in temp_type and True not in np.isin(temp_type,['TD','TS','HU']):
+                    count_ss_pure += 1
+
+                #Check for partially subtropical storms
+                if 'SS' in temp_type:
+                    count_ss_partial += 1
+
+            #Add generic season info
+            if multi_season == False:
+                narray = np.array(hurdat_year['max_wspd'])
+                narray = narray[~np.isnan(narray)]
+                #hurdat_year['season_storms'] = len(hurdat_year['name'])
+                hurdat_year['season_storms'] = len(narray)
+                hurdat_year['season_named'] = len(narray[narray>=34])
+                hurdat_year['season_hurricane'] = len(narray[narray>=65])
+                hurdat_year['season_major'] = len(narray[narray>=100])
+                hurdat_year['season_ace'] = np.round(np.sum(hurdat_year['ace']),1)
+                hurdat_year['season_subtrop_pure'] = count_ss_pure
+                hurdat_year['season_subtrop_partial'] = count_ss_partial
             else:
-                max_wnd = int(np.nanmax(temp_vmax[idx]))
-                max_cat = convert_category(np.nanmax(temp_vmax[idx]))
-            if len(np_slp[~np.isnan(np_slp)]) == 0:
-                min_slp = np.nan
-            else:
-                min_slp = int(np.nanmin(temp_mslp[idx]))
-
-            #Append to dict
-            hurdat_year['id'].append(key)
-            hurdat_year['name'].append(temp_name)
-            hurdat_year['max_wspd'].append(max_wnd)
-            hurdat_year['min_mslp'].append(min_slp)
-            hurdat_year['category'].append(max_cat)
-            hurdat_year['ace'].append(temp_ace)
-            hurdat_year['operational_id'].append(self.dict[key]['operational_id'])
-            
-            #Handle operational vs. non-operational storms
-
-            #Check for purely subtropical storms
-            if 'SS' in temp_type and True not in np.isin(temp_type,['TD','TS','HU']):
-                count_ss_pure += 1
-
-            #Check for partially subtropical storms
-            if 'SS' in temp_type:
-                count_ss_partial += 1
-
-        #Add generic season info
-        hurdat_year['season_storms'] = len(hurdat_year['name'])
-        narray = np.array(hurdat_year['max_wspd'])
-        narray = narray[~np.isnan(narray)]
-        hurdat_year['season_named'] = len(narray[narray>=34])
-        hurdat_year['season_hurricane'] = len(narray[narray>=65])
-        hurdat_year['season_major'] = len(narray[narray>=100])
-        hurdat_year['season_ace'] = np.sum(hurdat_year['ace'])
-        hurdat_year['season_subtrop_pure'] = count_ss_pure
-        hurdat_year['season_subtrop_partial'] = count_ss_partial
+                narray = np.array(hurdat_year['max_wspd'][season_idx])
+                narray = narray[~np.isnan(narray)]
+                #hurdat_year['season_storms'][season_idx] = len(hurdat_year['name'])
+                hurdat_year['season_storms'][season_idx] = len(narray)
+                hurdat_year['season_named'][season_idx] = len(narray[narray>=34])
+                hurdat_year['season_hurricane'][season_idx] = len(narray[narray>=65])
+                hurdat_year['season_major'][season_idx] = len(narray[narray>=100])
+                hurdat_year['season_ace'][season_idx] = np.round(np.sum(hurdat_year['ace'][season_idx]),1)
+                hurdat_year['season_subtrop_pure'][season_idx] = count_ss_pure
+                hurdat_year['season_subtrop_partial'][season_idx] = count_ss_partial
                 
         #Return object
         return hurdat_year

--- a/src/tropycal/tracks/tools.py
+++ b/src/tropycal/tracks/tools.py
@@ -63,35 +63,35 @@ def construct_title(thresh):
     else:
         thresh['sample_min']=0
         
-    if not np.isnan(thresh['V_min']):
-        plot_subtitle.append(f"{gteq} {thresh['V_min']}kt")
+    if not np.isnan(thresh['v_min']):
+        plot_subtitle.append(f"{gteq} {thresh['v_min']}kt")
     else:
-        thresh['V_min']=0
+        thresh['v_min']=0
         
-    if not np.isnan(thresh['P_max']):
-        plot_subtitle.append(f"{lteq} {thresh['P_max']}hPa")            
+    if not np.isnan(thresh['p_max']):
+        plot_subtitle.append(f"{lteq} {thresh['p_max']}hPa")            
     else:
-        thresh['P_max']=9999
+        thresh['p_max']=9999
 
-    if not np.isnan(thresh['dV_min']):
-        plot_subtitle.append(f"{gteq} {thresh['dV_min']}kt / {thresh['dt_window']}hr")            
+    if not np.isnan(thresh['dv_min']):
+        plot_subtitle.append(f"{gteq} {thresh['dv_min']}kt / {thresh['dt_window']}hr")            
     else:
-        thresh['dV_min']=-9999
+        thresh['dv_min']=-9999
 
-    if not np.isnan(thresh['dP_max']):
-        plot_subtitle.append(f"{lteq} {thresh['dP_max']}hPa / {thresh['dt_window']}hr")            
+    if not np.isnan(thresh['dp_max']):
+        plot_subtitle.append(f"{lteq} {thresh['dp_max']}hPa / {thresh['dt_window']}hr")            
     else:
-        thresh['dP_max']=9999
+        thresh['dp_max']=9999
     
-    if not np.isnan(thresh['dV_max']):
-        plot_subtitle.append(f"{lteq} {thresh['dV_max']}kt / {thresh['dt_window']}hr")            
+    if not np.isnan(thresh['dv_max']):
+        plot_subtitle.append(f"{lteq} {thresh['dv_max']}kt / {thresh['dt_window']}hr")            
     else:
-        thresh['dV_max']=9999
+        thresh['dv_max']=9999
 
-    if not np.isnan(thresh['dP_min']):
-        plot_subtitle.append(f"{gteq} {thresh['dP_min']}hPa / {thresh['dt_window']}hr")            
+    if not np.isnan(thresh['dp_min']):
+        plot_subtitle.append(f"{gteq} {thresh['dp_min']}hPa / {thresh['dt_window']}hr")            
     else:
-        thresh['dP_min']=-9999
+        thresh['dp_min']=-9999
     
     if len(plot_subtitle)>0:
         plot_subtitle = '\n'+', '.join(plot_subtitle)

--- a/tests/tracks.py
+++ b/tests/tracks.py
@@ -106,7 +106,7 @@ def test_code():
     #ax = season.plot(return_ax=True)
     
     #Annual summary
-    season.annual_summary()
+    season.summary()
     
     #Dataframe
     season.to_dataframe()


### PR DESCRIPTION
**New functions:**
- tropycal.tracks.Dataset:
  - 'download_tcr' : Downloads the NHC offical Tropical Cyclone Report (TCR) for the requested storm to the requested directory.

- tropycal.tracks.Storm:
  - 'sel_time' : Subset this storm's data by a range of times or for a single time.
  - 'query_nhc_discussions' : Searches for the given word or phrase through all NHC forecast discussions for this storm.

- tropycal.tracks.Season:
  - 'get_storm' : Retrieves a Storm object for the requested storm.

**New features and updates:**
- tropycal.tracks.Dataset:
  - Updated the default HURDATv2 source to reference the latest release through 2019.
  - In 'gridded_stats', the gridded 2D array can now be returned from the function as an xarray DataArray.
  - 'get_season' can now retrieve a composite of multiple seasons for HURDATv2 data.

- tropycal.tracks.Storm:
  - Storm objects now have variables included as attributes. For example, run "storm.lon" to retrieve all longitude points.
  - Added official NHC cone of uncertainty sizes for the 2020 Atlantic & Pacific Hurricane Seasons.

- tropycal.tracks.Season:
  - Season objects can now be added together using HURDATv2 data, for uses such as compositing seasons.
  - Renamed the "annual_summary" function as "summary", in part to reflect the use of multiple seasons.

**Bug fixes:**
- Overall:
  - Cleaned up documentation for numerous functions.

- tropycal.tracks.Storm:
  - When printing instance of Storm object, peak intensity statistics no longer include time spent as extratropical.
  - Fixed a bug for retrieving operational NHC forecasts for 2019.
  - An error message now appears when trying to download a tropical cyclone report (TCR) that doesn't exist.

- tropycal.tracks.Season:
  - Fixed the calculation for the ending time of the season.
