### PR TITLE
Remove geopy dependence

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ author = 'Tropycal Developers'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.2.5s'
+release = '0.2.6'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tropycal
-version = 0.2.5
+version = 0.2.6
 description = Package for retrieving and analyzing tropical cyclone data
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -31,7 +31,6 @@ install_requires =
     scipy>=1.1.0
     xarray>=0.10.7
     pandas>=0.23.0
-    geopy>=1.18.1
     networkx>=2.0.0
     requests>=2.22.0
 


### PR DESCRIPTION
Minor bug fix (& by necessity making a new version v0.2.6 for pip purposes) to remove the dependence on geopy which was previously not removed on pip.