### PR TITLE
Change JTWC Source from UCAR to NOAA

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ author = 'Tropycal Developers'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.2.6'
+release = '0.2.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tropycal
-version = 0.2.6
+version = 0.2.7
 description = Package for retrieving and analyzing tropical cyclone data
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -251,7 +251,7 @@ class Realtime():
         current_year = (dt.now()).year
 
         #Get list of files in online directory
-        urlpath = urllib.request.urlopen('http://hurricanes.ral.ucar.edu/repository/data/bdecks_open/')
+        urlpath = urllib.request.urlopen('https://www.ssd.noaa.gov/PS/TROP/DATA/ATCF/JTWC/')
         string = urlpath.read().decode('utf-8')
 
         #Get relevant filenames from directory
@@ -285,7 +285,7 @@ class Realtime():
                 add_basin = ''
 
             #add empty entry into dict
-            self.data[stormid] = {'id':stormid,'operational_id':stormid,'name':'','year':int(stormid[4:8]),'season':int(stormid[4:8]),'basin':add_basin,'source_info':'Joint Typhoon Warning Center','realtime':True,'source_method':"UCAR's Tropical Cyclone Guidance Project (TCGP)",'source_url':"http://hurricanes.ral.ucar.edu/repository/data/bdecks_open/"}
+            self.data[stormid] = {'id':stormid,'operational_id':stormid,'name':'','year':int(stormid[4:8]),'season':int(stormid[4:8]),'basin':add_basin,'source_info':'Joint Typhoon Warning Center','realtime':True,'source_method':"NOAA SSD",'source_url':"https://www.ssd.noaa.gov/PS/TROP/DATA/ATCF/JTWC/"}
             self.data[stormid]['source'] = 'jtwc'
 
             #add empty lists
@@ -294,7 +294,7 @@ class Realtime():
             self.data[stormid]['ace'] = 0.0
 
             #Read in file
-            url = f"http://hurricanes.ral.ucar.edu/repository/data/bdecks_open/{file}"
+            url = f"https://www.ssd.noaa.gov/PS/TROP/DATA/ATCF/JTWC/{file}"
             f = urllib.request.urlopen(url)
             content = f.read()
             content = content.decode("utf-8")
@@ -338,7 +338,8 @@ class Realtime():
                 #Get other relevant variables
                 btk_wind = int(line[8])
                 btk_mslp = int(line[9])
-                btk_type = get_storm_type(btk_wind,False)
+                btk_type = line[10]
+                if btk_type == "TY": btk_type = "HU"
                 name = line[27]
 
                 #Replace with NaNs

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -1094,7 +1094,7 @@ None,prop={},map_prop={}):
 
                 #Create 0.5 degree grid for plotting
                 gridlats = np.arange(0,90,0.25)
-                gridlons = np.arange(180-360.0,360-360.0,0.25)
+                gridlons = np.arange(180-360.0,180.0,0.25) #gridlons = np.arange(180-360.0,360-360.0,0.25)
                 gridlons2d,gridlats2d = np.meshgrid(gridlons,gridlats)
                 griddata = np.zeros((gridlons2d.shape))
 
@@ -1137,6 +1137,7 @@ None,prop={},map_prop={}):
                 #Update coordinate bounds
                 skip_bounds = False
                 if hr in ds[f'gefs_{i}']['fhr']:
+                    idx = ds[f'gefs_{i}']['fhr'].index(hr)
                     use_lats = ds[f'gefs_{i}']['lat'][:idx+1]
                     use_lons = ds[f'gefs_{i}']['lon'][:idx+1]
                 else:
@@ -1736,7 +1737,6 @@ None,prop={},map_prop={}):
                 cone_size = cone_size_pac[cone_year]
             else:
                 cone_size = 0
-                #raise RuntimeError("Error: No cone information is available for the requested basin.")
         
         elif cone_year > np.max([k for k in cone_size_atl.keys()]):
             cone_year = [k for k in cone_size_atl.keys()][0]
@@ -1759,7 +1759,7 @@ None,prop={},map_prop={}):
                 cone_size = 0
         
         #Fix for 2020 that now incorporates 60 hour forecasts
-        if fcst_year >= 2020:
+        if fcst_year >= 2020 and cone_size > 0:
             cone_climo_hr = [3,12,24,36,48,60,72,96,120]
             cone_size = cone_size[:5]+[np.mean(cone_size[4:6])]+cone_size[5:]
 


### PR DESCRIPTION
Several bug fixes and feature enhancements:

- RAL UCAR source for JTWC Best Track data which was used for Realtime objects stopped updating sometime in late June or early July. Data source was changed to NOAA, meaning Realtime objects can now read in global JTWC storm data again.
- The switch to NOAA's ATCF includes storm types for Realtime objects under JTWC's jurisdiction (e.g., TD, TS, SD, SS, DB), which was previously not available.
- The switch to NOAA's ATCF also allows for a-deck data to be read in, meaning `get_operational_forecasts()` for Storm objects used to retrieve operational and model forecasts now works for storms with JTWC as the data source. There is an archive back to 2016 available.
- `plot_gefs_ensembles()` now works for West Pacific storms as well as North Atlantic and East/Central Pacific basins.
- JTWC Prognostic Reasoning product can now be read into Realtime Storm objects via `get_discussion_realtime()`. This function supersedes `get_nhc_discussion_realtime()`, which will be deprecated in future Tropycal updates since forecast discussions can now be retrieved for all basins.