### PR TITLE
Change JTWC Source from UCAR to JTWC ATCF

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tropycal is a Python package intended to simplify the process of retrieving and 
 
 Tropycal can read in HURDAT2 and IBTrACS reanalysis data and operational National Hurricane Center (NHC) Best Track data and conform them to the same format, which can be used to perform climatological, seasonal and individual storm analyses. For each individual storm, operational NHC forecasts, aircraft reconnaissance data, and any associated tornado activity can be retrieved and plotted.
 
-The latest version of Tropycal is v0.2.5.
+The latest version of Tropycal is v0.2.8.
 
 ## Installation
 The currently recommended method of installation is via pip:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ author = 'Tropycal Developers'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.2.7'
+release = '0.2.8'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tropycal
-version = 0.2.7
+version = 0.2.8
 description = Package for retrieving and analyzing tropical cyclone data
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -251,7 +251,7 @@ class Realtime():
         current_year = (dt.now()).year
 
         #Get list of files in online directory
-        urlpath = urllib.request.urlopen('https://www.ssd.noaa.gov/PS/TROP/DATA/ATCF/JTWC/')
+        urlpath = urllib.request.urlopen(f'https://www.nrlmry.navy.mil/atcf_web/docs/tracks/{current_year}/')
         string = urlpath.read().decode('utf-8')
 
         #Get relevant filenames from directory
@@ -285,7 +285,7 @@ class Realtime():
                 add_basin = ''
 
             #add empty entry into dict
-            self.data[stormid] = {'id':stormid,'operational_id':stormid,'name':'','year':int(stormid[4:8]),'season':int(stormid[4:8]),'basin':add_basin,'source_info':'Joint Typhoon Warning Center','realtime':True,'source_method':"NOAA SSD",'source_url':"https://www.ssd.noaa.gov/PS/TROP/DATA/ATCF/JTWC/"}
+            self.data[stormid] = {'id':stormid,'operational_id':stormid,'name':'','year':int(stormid[4:8]),'season':int(stormid[4:8]),'basin':add_basin,'source_info':'Joint Typhoon Warning Center','realtime':True,'source_method':"JTWC ATCF",'source_url':f'https://www.nrlmry.navy.mil/atcf_web/docs/tracks/{current_year}/'}
             self.data[stormid]['source'] = 'jtwc'
 
             #add empty lists
@@ -294,7 +294,7 @@ class Realtime():
             self.data[stormid]['ace'] = 0.0
 
             #Read in file
-            url = f"https://www.ssd.noaa.gov/PS/TROP/DATA/ATCF/JTWC/{file}"
+            url = f"https://www.nrlmry.navy.mil/atcf_web/docs/tracks/{current_year}/{file}"
             f = urllib.request.urlopen(url)
             content = f.read()
             content = content.decode("utf-8")

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -332,7 +332,7 @@ class RealtimeStorm(Storm):
         else:
             
             #Get forecast for this storm
-            url = f"https://www.ssd.noaa.gov/PS/TROP/DATA/ATCF/JTWC/{self.id.lower()}.com"
+            url = f"https://www.nrlmry.navy.mil/atcf_web/docs/current_storms/{self.id.lower()}.sum"
             if requests.get(url).status_code != 200: raise RuntimeError("JTWC forecast data is unavailable for this storm.")
             
             #Read file content
@@ -340,27 +340,35 @@ class RealtimeStorm(Storm):
             content = f.read()
             content = content.decode("utf-8")
             content = content.split("\n")
-            content = [(i.replace(" ","")).split(",") for i in content]
             f.close()
 
             #Iterate through every line in content:
+            run_init = content[2].split(" ")[0]
             forecasts = {}
 
-            for line in content:
-
+            for line in content[3:]:
+                
+                #Exit once done retrieving forecast
+                if line == "AMP": break
+                
                 #Get basic components
-                lineArray = [i.replace(" ","") for i in line]
-                if len(lineArray) < 11: continue
-                basin,number,run_init,n_a,model,fhr,lat,lon,vmax,mslp,stype = lineArray[:11]
-                if model not in ["JTWC"]: continue
-
+                lineArray = line.split(" ")
+                if len(lineArray) < 4: continue
+                
+                #Exit once done retrieving forecast
+                if lineArray[0] == "AMP": break
+                    
                 if len(forecasts) == 0:
                     forecasts = {
                         'fhr':[],'lat':[],'lon':[],'vmax':[],'mslp':[],'cumulative_ace':[],'type':[],'init':dt.strptime(run_init,'%Y%m%d%H')
                     }
 
+                #Forecast hour
+                fhr = int(lineArray[0].split("T")[1])
+                
                 #Format lat & lon
-                fhr = int(fhr)
+                lat = lineArray[1]
+                lon = lineArray[2]
                 if "N" in lat:
                     lat_temp = lat.split("N")[0]
                     lat = np.round(float(lat_temp) * 0.1,1)
@@ -375,35 +383,22 @@ class RealtimeStorm(Storm):
                     lon = np.round(float(lon_temp) * 0.1,1)
 
                 #Format vmax & MSLP
-                if vmax == '':
-                    vmax = np.nan
-                else:
-                    vmax = int(vmax)
-                    if vmax < 10 or vmax > 300: vmax = np.nan
-                if mslp == '':
-                    mslp = np.nan
-                else:
-                    mslp = int(mslp)
-                    if mslp < 1: mslp = np.nan
+                vmax = int(lineArray[3])
+                if vmax < 10 or vmax > 300: vmax = np.nan
+                mslp = np.nan
 
                 #Add forecast data to dict if forecast hour isn't already there
                 if fhr not in forecasts['fhr']:
-                    if model in ['OFCL','OFCI'] and fhr > 120:
-                        pass
-                    else:
-                        if lat == 0.0 and lon == 0.0:
-                            continue
-                        forecasts['fhr'].append(fhr)
-                        forecasts['lat'].append(lat)
-                        forecasts['lon'].append(lon)
-                        forecasts['vmax'].append(vmax)
-                        forecasts['mslp'].append(mslp)
+                    if lat == 0.0 and lon == 0.0: continue
+                    forecasts['fhr'].append(fhr)
+                    forecasts['lat'].append(lat)
+                    forecasts['lon'].append(lon)
+                    forecasts['vmax'].append(vmax)
+                    forecasts['mslp'].append(mslp)
 
-                        #Get storm type, if it can be determined
-                        if stype in ['','DB'] and vmax != 0 and np.isnan(vmax) == False:
-                            stype = get_storm_type(vmax,False)
-                        if stype == 'TY': stype = 'HU'
-                        forecasts['type'].append(stype)
+                    #Get storm type, if it can be determined
+                    stype = get_storm_type(vmax,False)
+                    forecasts['type'].append(stype)
             
         #Determine ACE thus far (prior to initial forecast hour)
         ace = 0.0

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -402,6 +402,7 @@ class RealtimeStorm(Storm):
                         #Get storm type, if it can be determined
                         if stype in ['','DB'] and vmax != 0 and np.isnan(vmax) == False:
                             stype = get_storm_type(vmax,False)
+                        if stype == 'TY': stype = 'HU'
                         forecasts['type'].append(stype)
             
         #Determine ACE thus far (prior to initial forecast hour)

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -884,11 +884,12 @@ class Storm:
             if ens < 10: return f"AP0{ens}"
             return f"AP{ens}"
 
-        #Get GFS forecast entry
+        #Get GFS forecast entry (AVNX is valid for RAL a-deck source)
+        gfs_key = 'AVNO' if 'AVNO' in self.forecast_dict.keys() else 'AVNX'
         try:
-            forecast_gfs = self.forecast_dict['AVNO'][forecast.strftime("%Y%m%d%H")]
+            forecast_gfs = self.forecast_dict[gfs_key][forecast.strftime("%Y%m%d%H")]
         except:
-            raise RuntimeError("The requested initialization isn't available for this storm.")
+            raise RuntimeError("The requested GFS initialization isn't available for this storm.")
         
         #Enter into dict entry
         ds['gfs']['fhr'] = [int(i) for i in forecast_gfs['fhr']]
@@ -1539,7 +1540,7 @@ class Storm:
             if storm_year < 2016:
                 msg = "Forecast data is unavailable for JTWC storms prior to 2016."
                 raise RuntimeError(msg)
-            url_models = f"https://www.ssd.noaa.gov/PS/TROP/DATA/ATCF/JTWC/a{self.id.lower()}.dat"
+            url_models = f"http://hurricanes.ral.ucar.edu/repository/data/adecks_open/a{self.id.lower()}.dat"
             
             #Retrieve model data text
             try:


### PR DESCRIPTION
Several critical bug fixes:

- RAL UCAR source for JTWC Best Track data which was used for Realtime objects stopped updating sometime in late June or early July. Tropycal v0.2.7 changed this data source was changed to NOAA SSD, but this source also stopped updating not long after the update. The source was now changed to the JTWC ATCF, meaning Realtime objects can now read in global JTWC storm data again. Hopefully this source is a longer term stable fix not requiring any further major updates.
- The switch to JTWC's ATCF includes storm types for Realtime objects under JTWC's jurisdiction (e.g., TD, TS, SD, SS, DB), which was previously available with the NOAA JTWC source (v0.2.7) but previously not available with the RAL UCAR source (v0.2.6 and prior).
- With the NOAA source down, a-deck data is now being read from RAL UCAR, which has most of the same models the NOAA source had but with different acronyms for some. This means `get_operational_forecasts()` for Storm objects used to retrieve operational and model forecasts still works for storms with JTWC as the data source.
- `plot_gefs_ensembles()` still works for West Pacific storms with this change.