### PR TITLE
Make JTWC Optional in Realtime Objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tropycal is a Python package intended to simplify the process of retrieving and 
 
 Tropycal can read in HURDAT2 and IBTrACS reanalysis data and operational National Hurricane Center (NHC) Best Track data and conform them to the same format, which can be used to perform climatological, seasonal and individual storm analyses. For each individual storm, operational NHC forecasts, aircraft reconnaissance data, and any associated tornado activity can be retrieved and plotted.
 
-The latest version of Tropycal is v0.2.9.
+The latest version of Tropycal is v0.2.10.
 
 ## Installation
 The currently recommended method of installation is via pip:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ author = 'Tropycal Developers'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.2.9'
+release = '0.2.10'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tropycal
-version = 0.2.9
+version = 0.2.10
 description = Package for retrieving and analyzing tropical cyclone data
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -62,7 +62,7 @@ class Realtime():
     def __getitem__(self, key):
         return self.__dict__[key]
     
-    def __init__(self):
+    def __init__(self,jtwc=False):
         
         #Define empty dict to store track data in
         self.data = {}
@@ -73,7 +73,7 @@ class Realtime():
         
         #Read in best track data
         self.__read_btk()
-        self.__read_btk_jtwc()
+        if jtwc == True: self.__read_btk_jtwc()
         
         #Determine time elapsed
         time_elapsed = dt.now() - start_time

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -115,10 +115,10 @@ class TrackPlot(Plot):
             type_array = np.array(storm_data['type'])
             idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))
             use_lats = (np.array(storm_data['lat'])[idx]).tolist()
-            use_lons = (np.array(storm_data['lon'])[idx]).tolist()
+            use_lons = (np.array(lons)[idx]).tolist()
         else:
             use_lats = storm_data['lat']
-            use_lons = storm_data['lon']
+            use_lons = np.copy(lons).tolist()
         
         if max_lat == None:
             max_lat = max(use_lats)


### PR DESCRIPTION
Critical bug fixes:

- Once again, the latest JTWC source is now not functioning, making it near impossible to retrieve best track data (and an archive of said best track data) for JTWC storms. As such, when creating an instance of a `realtime.Realtime()` object, there is now a flag set by default to `jtwc=False`, therefore disabling JTWC by default. If one wishes to use JTWC and try their luck, change this flag to True. Once a stable source of JTWC data is available, setting this flag to True will hopefully work.
- Another critical bug was identified where cross-dateline plotting for storms was broken. This bug has now been fixed.