### PR TITLE
Add realtime invest handling capabilities

### DIFF
--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -61,6 +61,7 @@ class RealtimeStorm(Storm):
         #Format keys for summary
         type_array = np.array(self.dict['type'])
         idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))[0]
+        if self.invest == True: idx = np.array([True for i in type_array])
         if len(idx) == 0:
             start_date = 'N/A'
             end_date = 'N/A'
@@ -154,6 +155,10 @@ class RealtimeStorm(Storm):
             Filepath to save the image in. If blank, default is current working directory.
         """
         
+        #Check to ensure storm is not an invest
+        if self.invest == True:
+            raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
+        
         #Determine data source
         if self.source == 'hurdat':
             part1 = f"AT{self.id[2:4]}" if self.id[0:2] == "AL" else self.id[0:4]
@@ -186,6 +191,10 @@ class RealtimeStorm(Storm):
         #Warn about pending deprecation
         warnings.warn("'get_nhc_discussion_realtime' will be deprecated in future Tropycal versions, use 'get_discussion_realtime' instead",DeprecationWarning)
         
+        #Check to ensure storm is not an invest
+        if self.invest == True:
+            raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
+        
         #Get latest forecast discussion for HURDAT source storm objects
         if self.source == "hurdat":
             return self.get_nhc_discussion(forecast=-1)
@@ -216,6 +225,10 @@ class RealtimeStorm(Storm):
         dict
             Dict entry containing the latest official forecast discussion.
         """
+        
+        #Check to ensure storm is not an invest
+        if self.invest == True:
+            raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Get latest forecast discussion for HURDAT source storm objects
         if self.source == "hurdat":
@@ -251,6 +264,10 @@ class RealtimeStorm(Storm):
         -----
         This dictionary includes a calculation for accumulated cyclone energy (ACE), cumulatively for the storm's lifespan through each forecast hour. This is done by linearly interpolating the forecast to 6-hour intervals and calculating 6-hourly ACE at each interval. For storms where forecast tropical cyclone type is available, ACE is not calculated for forecast periods that are neither tropical nor subtropical.
         """
+        
+        #Check to ensure storm is not an invest
+        if self.invest == True:
+            raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #NHC forecast data
         if self.source == 'hurdat':
@@ -479,6 +496,10 @@ class RealtimeStorm(Storm):
             Property of cartopy map.
         """
         
+        #Check to ensure storm is not an invest
+        if self.invest == True:
+            raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
+        
         #Create instance of plot object
         try:
             self.plot_obj
@@ -539,6 +560,12 @@ class RealtimeStorm(Storm):
         if source == 'public_advisory' and self.source != 'hurdat':
             msg = "A source of 'public_advisory' can only be used for storms in NHC's area of responsibility."
             raise RuntimeError(msg)
+        
+        #Check to ensure storm is not an invest
+        if self.invest == True:
+            msg = "NHC does not issue public advisories on invests. Defaulting to best track method."
+            warnings.warn(msg)
+            source = 'best_track'
         
         #Declare empty dict
         current_advisory = {}

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -2692,7 +2692,7 @@ class TrackDataset:
                 if isinstance(y_r,(list,tuple)) == False:
                     msg = "\"year_range\" and \"year_range_subtract\" must be of type list or tuple."
                     raise ValueError(msg)
-                if len(year_range_subtract) != 2:
+                if year_range_subtract is not None and len(year_range_subtract) != 2:
                     msg = "\"year_range\" and \"year_range_subtract\" must contain 2 elements."                
                     raise ValueError(msg)
                 new_y_r = (max((start_year,min(y_r))),min((end_year,max(y_r))))

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -9,7 +9,8 @@ import urllib
 import warnings
 from datetime import datetime as dt,timedelta
 from scipy.ndimage import gaussian_filter as gfilt
-#Import other tropycal objects
+
+#Import internal scripts
 from ..plot import Plot
 from .plot import TrackPlot
 from .storm import Storm

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -1,16 +1,14 @@
 import os, sys
 import calendar
 import numpy as np
-import pandas as pd
-import re
 import scipy.interpolate as interp
-import urllib
 import warnings
 from datetime import datetime as dt,timedelta
 import scipy.ndimage as ndimage
 import networkx as nx
 from scipy.ndimage import gaussian_filter as gfilt
 
+#Import internal scripts
 from ..plot import Plot
 
 #Import tools

--- a/src/tropycal/tracks/season.py
+++ b/src/tropycal/tracks/season.py
@@ -1,15 +1,12 @@
 r"""Functionality for storing and analyzing a year/season of cyclones."""
 
-import calendar
 import numpy as np
 import pandas as pd
-import re
-import scipy.interpolate as interp
-import urllib
 import warnings
 from datetime import datetime as dt,timedelta
 from copy import copy
 
+#Import internal scripts
 from .plot import TrackPlot
 from .storm import Storm
 

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -69,6 +69,7 @@ class Storm:
         
         #Format keys for summary
         type_array = np.array(self.dict['type'])
+        if self.invest == True: idx = np.array([True for i in type_array])
         idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))[0]
         if len(idx) == 0:
             start_date = 'N/A'
@@ -130,6 +131,7 @@ class Storm:
             self.vars = {}
             for key in keys:
                 if key == 'realtime': continue
+                if key == 'invest': continue
                 if isinstance(self.dict[key], list) == False and isinstance(self.dict[key], dict) == False:
                     self[key] = self.dict[key]
                     self.coords[key] = self.dict[key]
@@ -156,6 +158,14 @@ class Storm:
             else:
                 self.realtime = False
                 self.coords['realtime'] = False
+            
+            #Determine if storm object is an invest
+            if 'invest' in keys and self.dict['invest'] == True:
+                self.invest = True
+                self.coords['invest'] = True
+            else:
+                self.invest = False
+                self.coords['invest'] = False
         
         else:
             
@@ -683,6 +693,10 @@ class Storm:
         if self.source != "hurdat":
             raise RuntimeError("Error: NHC data can only be accessed when HURDAT is used as the data source.")
         
+        #Check to ensure storm is not an invest
+        if self.invest == True:
+            raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
+        
         #Create instance of plot object
         try:
             self.plot_obj
@@ -983,6 +997,10 @@ class Storm:
         #Check to ensure the data source is HURDAT
         if self.source != "hurdat":
             raise RuntimeError("Error: NHC data can only be accessed when HURDAT is used as the data source.")
+        
+        #Check to ensure storm is not an invest
+        if self.invest == True:
+            raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Get storm ID & corresponding data URL
         storm_id = self.dict['operational_id']
@@ -1303,6 +1321,10 @@ class Storm:
             msg = "Error: NHC data can only be accessed when HURDAT is used as the data source."
             raise RuntimeError(msg)
         
+        #Check to ensure storm is not an invest
+        if self.invest == True:
+            raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
+        
         #Get storm ID & corresponding data URL
         storm_id = self.dict['operational_id']
         storm_year = self.dict['year']
@@ -1432,6 +1454,10 @@ class Storm:
         if self.source != "hurdat":
             msg = "Error: NHC data can only be accessed when HURDAT is used as the data source."
             raise RuntimeError(msg)
+        
+        #Check to ensure storm is not an invest
+        if self.invest == True:
+            raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Get storm ID & corresponding data URL
         storm_id = self.dict['operational_id']
@@ -1630,6 +1656,10 @@ class Storm:
         save_path : str
             Path of directory to download the TCR into. Default is current working directory.
         """
+        
+        #Check to ensure storm is not an invest
+        if self.invest == True:
+            raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Error check
         if self.source != "hurdat":

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -1,6 +1,5 @@
 r"""Functionality for storing and analyzing an individual storm."""
 
-import calendar
 import numpy as np
 import pandas as pd
 import re
@@ -9,8 +8,9 @@ import urllib
 import warnings
 from datetime import datetime as dt,timedelta
 import requests
-import copy 
+import copy
 
+#Import internal scripts
 from .plot import TrackPlot
 from ..tornado import *
 from ..recon import *


### PR DESCRIPTION
- Add invest handling capabilities to Realtime objects. Invests are assigned to Storm objects, but all functions that are not applicable for invests (e.g., NHC forecast discussions) return errors.
- Fixed a bug in the NHC forecast cone that affected 72-120 hour cone size calculations after 2019.