### PR TITLE
Prep for v0.3: clean code & docs, bug fixes & add WPC storm rainfall

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,19 @@ Tropycal is a Python package intended to simplify the process of retrieving and 
 
 Tropycal can read in HURDAT2 and IBTrACS reanalysis data and operational National Hurricane Center (NHC) Best Track data and conform them to the same format, which can be used to perform climatological, seasonal and individual storm analyses. For each individual storm, operational NHC forecasts, aircraft reconnaissance data, and any associated tornado activity can be retrieved and plotted.
 
-The latest version of Tropycal is v0.2.10.
+The latest version of Tropycal is v0.3.
 
 ## Installation
 The currently recommended method of installation is via pip:
 
 ```sh
 pip install tropycal
+```
+
+Installation is also available via conda:
+
+```sh
+conda install -c conda-forge tropycal
 ```
 
 Tropycal can also be installed by cloning the GitHub repository:

--- a/README.md
+++ b/README.md
@@ -6,19 +6,27 @@ Tropycal can read in HURDAT2 and IBTrACS reanalysis data and operational Nationa
 The latest version of Tropycal is v0.3.
 
 ## Installation
-The currently recommended method of installation is via pip:
 
-```sh
-pip install tropycal
-```
 
-Installation is also available via conda:
+### Conda
+
+The currently recommended method of installation is via conda:
 
 ```sh
 conda install -c conda-forge tropycal
 ```
 
-Tropycal can also be installed by cloning the GitHub repository:
+### Pip
+
+Installation is also available via pip:
+
+```sh
+pip install tropycal
+```
+
+### From source
+
+Tropycal can also be installed from source by cloning the GitHub repository:
 
 ```sh
 git clone https://github.com/tropycal/tropycal

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,62 +1,31 @@
-{{ objname }}
-{{ underline }}
+{{ fullname | escape | underline}}
 
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
 
-   {% block attributes_summary %}
+   {% block methods %}
+   {% block attributes %}
    {% if attributes %}
-
-   .. rubric:: Attributes Summary
-
-   .. autosummary::
-   {% for item in attributes %}
-      ~{{ name }}.{{ item }}
-   {%- endfor %}
-
+      .. autosummary::
+         :toctree:
+      {% for item in all_attributes %}
+         {%- if not item.startswith('_') %}
+         {{ name }}.{{ item }}
+         {%- endif -%}
+      {%- endfor %}
    {% endif %}
    {% endblock %}
+   
+   Methods Summary
 
-   {% block methods_summary %}
    {% if methods %}
-
-   .. rubric:: Methods Summary
-
-   .. autosummary::
-   {% for item in methods %}
-      ~{{ name }}.{{ item }}
-   {%- endfor %}
-
+      .. autosummary::
+         :toctree:
+      {% for item in all_methods %}
+         {%- if not item.startswith('_') or item in ['__call__'] %}
+         {{ name }}.{{ item }}
+         {%- endif -%}
+      {%- endfor %}
    {% endif %}
    {% endblock %}
-
-   {% block attributes_documentation %}
-   {% if attributes %}
-
-   .. rubric:: Attributes Documentation
-
-   {% for item in attributes %}
-   .. autoattribute:: {{ item }}
-   {%- endfor %}
-
-   {% endif %}
-   {% endblock %}
-
-   {% block methods_documentation %}
-   {% if methods %}
-
-   .. rubric:: Methods Documentation
-
-   {% for item in methods %}
-   .. automethod:: {{ item }}
-   {%- endfor %}
-
-   {% endif %}
-   {% endblock %}
-
-.. include:: {{fullname}}.examples
-
-.. raw:: html
-
-     <div style='clear:both'></div>

--- a/docs/_templates/overrides/tropycal.utils.rst
+++ b/docs/_templates/overrides/tropycal.utils.rst
@@ -19,6 +19,16 @@ Generic Utilities
       get_storm_type
 
 
+Cartopy Utilities
+-----------------
+
+   .. autosummary::
+      :toctree: ./
+
+      add_tropycal
+      plot_storm
+
+
 Colors
 ------
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,6 +10,7 @@ API Reference
 
    tropycal.tracks
    tropycal.tornado
+   tropycal.rain
    tropycal.recon
    tropycal.realtime
    tropycal.utils

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,13 +27,13 @@ sys.path.insert(0, os.path.abspath('../plot'))
 # -- Project information -----------------------------------------------------
 
 project = 'tropycal'
-copyright = '2020, Tropycal Developers'
+copyright = '2021, Tropycal Developers'
 author = 'Tropycal Developers'
 
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.2.10'
+release = '0.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -19,6 +19,8 @@ The HURDAT2_ reanalysis is an actively updated reanalysis dataset for tropical c
 
 ----
 
+.. _ibtracs-caveats:
+
 IBTrACS
 -------
 The IBTrACS_ reanalysis is a comprehensive dataset combining tropical cyclone data from multiple WMO agencies across the world. IBTrACS contains many data sources, some which have advantages over others. This results in discrepancies in storm tracks, storms that were or were not tropical, or sustained wind measurement that vary between agency. tropycal offers 3 modes of reading in IBTrACS data, with the pros and cons of each method listed below.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Tropycal is supported for Python >= 3.6. For examples on how to use Tropycal in 
 Latest Version
 ==============
 
-The latest version of Tropycal as of 12 September 2020 is v0.2.4. This documentation is valid for the latest version of Tropycal.
+The latest version of Tropycal as of 7 September 2021 is v0.3. This documentation is valid for the latest version of Tropycal.
 
 Indices and tables
 ==================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -22,13 +22,22 @@ To fully leverage tropycal's plotting capabilities, it is strongly recommended t
 Installation
 ------------
 
+From Conda
+~~~~~~~~~~
+
 As of v0.3, Tropycal can be installed via conda::
 
     conda install -c conda-forge tropycal
 
+From Pip
+~~~~~~~~
+
 As with before, Tropycal can also be installed via pip::
 
     pip install tropycal
+
+From Source
+~~~~~~~~~~~
 
 Tropycal can also be installed via cloning it from github. Running the following commands
 will build and install tropycal into your python installation::

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -22,7 +22,11 @@ To fully leverage tropycal's plotting capabilities, it is strongly recommended t
 Installation
 ------------
 
-The currently recommended method of installation is via pip::
+As of v0.3, Tropycal can be installed via conda::
+
+    conda install -c conda-forge tropycal
+
+As with before, Tropycal can also be installed via pip::
 
     pip install tropycal
 

--- a/docs/options/map_prop.rst
+++ b/docs/options/map_prop.rst
@@ -63,11 +63,13 @@ The following properties are available for any function that involves plotting s
    * - dots
      - Boolean whether to plot storm track dots along the storm track. Default is False.
    * - fillcolor
-     - Fill color for storm track dots. If 'category', then uses a color scale varying by category.
+     - Fill color for storm track dots. If 'category', then uses a color scale varying by SSHWS category. This can also be 'vmax' or 'mslp' for coloring by variable value.
    * - linecolor
-     - Line color for storm track. If 'category', then uses a color scale varying by category.
-   * - category_colors
-     - Color scale to use for categories. Default is 'default'. Currently no other option is available.
+     - Line color for storm track. If 'category', then uses a color scale varying by SSHWS category. This can also be 'vmax' or 'mslp' for coloring by variable value.
+   * - cmap
+     - Colormap used for fill and/or line color, if not a single color nor 'category'.
+   * - levels
+     - List of levels corresponding to cmap, if not coloring by a single color nor 'category'.
    * - linewidth
      - Line width for storm track. Default varies by function.
    * - ms

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tropycal
-version = 0.2.10
+version = 0.3
 description = Package for retrieving and analyzing tropical cyclone data
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/tropycal/plot/plot.py
+++ b/src/tropycal/plot/plot.py
@@ -178,7 +178,7 @@ class Plot:
         #Return map bounds
         return bound_w,bound_e,bound_s,bound_n
     
-    def plot_lat_lon_lines(self,bounds):
+    def plot_lat_lon_lines(self,bounds,zorder=None):
         
         r"""
         Plots parallels and meridians that are constrained by the map bounds.
@@ -225,10 +225,17 @@ class Plot:
             all_meridians = np.arange(0.0,360.0+rthres,rthres)
             all_parallels = np.arange(rdown(-90.0,rthres),90.0+rthres,rthres)
             
-            #First call with no labels but gridlines plotted
-            gl1 = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=False,xlocs=all_meridians,ylocs=all_parallels,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted')
-            #Second call with labels but no gridlines
-            gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,xlocs=meridians,ylocs=parallels,linewidth=0.0,color='k',alpha=0.0,linestyle='dotted')
+            if zorder == None:
+                #First call with no labels but gridlines plotted
+                gl1 = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=False,xlocs=all_meridians,ylocs=all_parallels,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted')
+                #Second call with labels but no gridlines
+                gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,xlocs=meridians,ylocs=parallels,linewidth=0.0,color='k',alpha=0.0,linestyle='dotted')
+            else:
+                #First call with no labels but gridlines plotted
+                gl1 = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=False,xlocs=all_meridians,ylocs=all_parallels,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted',zorder=zorder)
+                #Second call with labels but no gridlines
+                gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,xlocs=meridians,ylocs=parallels,linewidth=0.0,color='k',alpha=0.0,linestyle='dotted',zorder=zorder)
+            
             gl.xlabels_top = False
             gl.ylabels_right = False
             gl.xlocator = mticker.FixedLocator(meridians2)
@@ -238,7 +245,10 @@ class Plot:
 
         else:
             #Add meridians and parallels
-            gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted')
+            if zorder == None:
+                gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted')
+            else:
+                gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted',zorder=zorder)
             gl.xlabels_top = False
             gl.ylabels_right = False
             gl.xlocator = mticker.FixedLocator(meridians)
@@ -249,7 +259,7 @@ class Plot:
         #Reset plot bounds
         self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
         
-    def plot_init(self,ax,map_prop):
+    def plot_init(self,ax,map_prop,plot_geography=True):
         
         r"""
         Initializes the plot by creating a cartopy and axes instance, if one hasn't been created yet, and adds geography.
@@ -278,7 +288,8 @@ class Plot:
             self.ax = ax
         
         #Attach geography to plot, lat/lon lines, etc.
-        self.create_geography(map_prop)
+        if plot_geography == True:
+            self.create_geography(map_prop)
     
     def add_prop(self,input_prop,default_prop):
         
@@ -393,9 +404,9 @@ class Plot:
                 msg = "Custom domains must be of type dict."
                 raise TypeError(msg)
             
+            #Retrieve map bounds
             keys = domain.keys()
             check = [False, False, False, False]
-            values = [0, 0, 0, 0]
             for key in keys:
                 if key[0].lower() == 'n': check[0] = True; bound_n = domain[key]
                 if key[0].lower() == 's': check[1] = True; bound_s = domain[key]
@@ -421,4 +432,10 @@ class Plot:
                     transform=self.ax.transAxes,ha='right',va='bottom',zorder=10)
             a.set_path_effects([path_effects.Stroke(linewidth=5, foreground='white'),
                            path_effects.Normal()])
-        
+    
+    def rgb(self,rgb):
+        r,g,b = rgb
+        r = int(r)
+        g = int(g)
+        b = int(b)
+        return '#%02x%02x%02x' % (r, g, b)

--- a/src/tropycal/plot/plot.py
+++ b/src/tropycal/plot/plot.py
@@ -67,7 +67,7 @@ class Plot:
         """
         
         #Initialize an instance of cartopy if not passed
-        if mapobj == None:
+        if mapobj is None:
             self.proj = getattr(ccrs, proj)(**kwargs)
         else:
             self.proj = mapobj
@@ -225,7 +225,7 @@ class Plot:
             all_meridians = np.arange(0.0,360.0+rthres,rthres)
             all_parallels = np.arange(rdown(-90.0,rthres),90.0+rthres,rthres)
             
-            if zorder == None:
+            if zorder is None:
                 #First call with no labels but gridlines plotted
                 gl1 = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=False,xlocs=all_meridians,ylocs=all_parallels,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted')
                 #Second call with labels but no gridlines
@@ -245,7 +245,7 @@ class Plot:
 
         else:
             #Add meridians and parallels
-            if zorder == None:
+            if zorder is None:
                 gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted')
             else:
                 gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted',zorder=zorder)
@@ -273,11 +273,11 @@ class Plot:
         """
 
         #create cartopy projection, if none existing
-        if self.proj == None:
+        if self.proj is None:
             self.create_cartopy(proj='PlateCarree',central_longitude=0.0)
         
         #create figure
-        if ax == None:
+        if ax is None:
             self.fig = plt.figure(figsize=map_prop['figsize'],dpi=map_prop['dpi'])
             self.ax = plt.axes(projection=self.proj)
         else:

--- a/src/tropycal/plot/plot.py
+++ b/src/tropycal/plot/plot.py
@@ -288,7 +288,7 @@ class Plot:
             self.ax = ax
         
         #Attach geography to plot, lat/lon lines, etc.
-        if plot_geography == True:
+        if plot_geography:
             self.create_geography(map_prop)
     
     def add_prop(self,input_prop,default_prop):

--- a/src/tropycal/plot/plot.py
+++ b/src/tropycal/plot/plot.py
@@ -214,6 +214,10 @@ class Plot:
         parallels = np.arange(rdown(bound_s,rthres),rup(bound_n,rthres)+rthres,rthres)
         meridians = np.arange(rdown(bound_w,rthres),rup(bound_e,rthres)+rthres,rthres)
         
+        add_kwargs = {}
+        if zorder is not None:
+            add_kwargs = {'zorder':zorder}
+        
         #Fix for dateline crossing
         if self.proj.proj4_params['lon_0'] == 180.0:
             
@@ -225,16 +229,10 @@ class Plot:
             all_meridians = np.arange(0.0,360.0+rthres,rthres)
             all_parallels = np.arange(rdown(-90.0,rthres),90.0+rthres,rthres)
             
-            if zorder is None:
-                #First call with no labels but gridlines plotted
-                gl1 = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=False,xlocs=all_meridians,ylocs=all_parallels,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted')
-                #Second call with labels but no gridlines
-                gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,xlocs=meridians,ylocs=parallels,linewidth=0.0,color='k',alpha=0.0,linestyle='dotted')
-            else:
-                #First call with no labels but gridlines plotted
-                gl1 = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=False,xlocs=all_meridians,ylocs=all_parallels,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted',zorder=zorder)
-                #Second call with labels but no gridlines
-                gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,xlocs=meridians,ylocs=parallels,linewidth=0.0,color='k',alpha=0.0,linestyle='dotted',zorder=zorder)
+            #First call with no labels but gridlines plotted
+            gl1 = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=False,xlocs=all_meridians,ylocs=all_parallels,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted',**add_kwargs)
+            #Second call with labels but no gridlines
+            gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,xlocs=meridians,ylocs=parallels,linewidth=0.0,color='k',alpha=0.0,linestyle='dotted',**add_kwargs)
             
             gl.xlabels_top = False
             gl.ylabels_right = False
@@ -245,10 +243,7 @@ class Plot:
 
         else:
             #Add meridians and parallels
-            if zorder is None:
-                gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted')
-            else:
-                gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted',zorder=zorder)
+            gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted',**add_kwargs)
             gl.xlabels_top = False
             gl.ylabels_right = False
             gl.xlocator = mticker.FixedLocator(meridians)

--- a/src/tropycal/rain/__init__.py
+++ b/src/tropycal/rain/__init__.py
@@ -1,0 +1,7 @@
+r"""Functionality for reading and analyzing tropical cyclone rain data."""
+
+from .dataset import RainDataset
+
+import sys
+if 'sphinx' not in sys.modules:
+    from .plot import RainPlot

--- a/src/tropycal/rain/dataset.py
+++ b/src/tropycal/rain/dataset.py
@@ -82,8 +82,7 @@ class RainDataset():
         
         #Check if data is empty
         if len(df_storm) == 0:
-            msg = "No rainfall data is available for this storm."
-            raise RuntimeError(msg)
+            raise RuntimeError("No rainfall data is available for this storm.")
         
         #Return dataframe
         return df_storm

--- a/src/tropycal/rain/dataset.py
+++ b/src/tropycal/rain/dataset.py
@@ -78,9 +78,7 @@ class RainDataset():
         df_storm = df_storm.drop(columns=['Storm','Year'])
         
         #Remove NaN entries
-        df_storm = df_storm.loc[~np.isnan(df_storm['Lat'])]
-        df_storm = df_storm.loc[~np.isnan(df_storm['Lon'])]
-        df_storm = df_storm.loc[~np.isnan(df_storm['Total'])]
+        df_storm = df_storm.loc[~np.isnan(df_storm['Lat']) & ~np.isnan(df_storm['Lon']) & ~np.isnan(df_storm['Total'])]
         
         #Check if data is empty
         if len(df_storm) == 0:

--- a/src/tropycal/rain/dataset.py
+++ b/src/tropycal/rain/dataset.py
@@ -144,7 +144,7 @@ class RainDataset():
         else:
             return {'grid':grid,'lat':grid_lat,'lon':grid_lon}
 
-    def plot_rain_grid(self,storm,grid,levels=None,cmap=None,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+    def plot_rain_grid(self,storm,grid,levels=None,cmap=None,domain="dynamic",plot_all_dots=False,ax=None,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a storm track and its associated rainfall (gridded).
@@ -165,8 +165,6 @@ class RainDataset():
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         save_path : str
@@ -178,6 +176,11 @@ class RainDataset():
             Customization properties of storm track lines. Please refer to :ref:`options-prop` for available options.
         map_prop : dict
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         """
         
         #Check if Storm object contains rainfall data
@@ -201,12 +204,12 @@ class RainDataset():
             self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
-        plot_ax = self.plot_obj.plot_storm(storm,grid,levels,cmap,domain,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_storm(storm,grid,levels,cmap,domain,plot_all_dots,ax=ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax is not None or return_ax == True: return plot_ax
+        return plot_ax
 
-    def plot_rain(self,storm,ms=7.5,mec=None,mew=0.5,minimum_threshold=1.0,levels=None,cmap=None,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+    def plot_rain(self,storm,ms=7.5,mec=None,mew=0.5,minimum_threshold=1.0,levels=None,cmap=None,domain="dynamic",plot_all_dots=False,ax=None,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a storm track and its associated rainfall (individual dots).
@@ -233,8 +236,6 @@ class RainDataset():
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         save_path : str
@@ -246,6 +247,11 @@ class RainDataset():
             Customization properties of storm track lines. Please refer to :ref:`options-prop` for available options.
         map_prop : dict
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         """
         
         #Check if Storm object contains rainfall data
@@ -270,7 +276,7 @@ class RainDataset():
             self.plot_obj.proj = cartopy_proj
             
         #Plot storm
-        plot_ax = self.plot_obj.plot_storm(storm,{'ms':ms,'minimum_threshold':minimum_threshold,'mew':mew,'mec':mec},levels,cmap,domain,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_storm(storm,{'ms':ms,'minimum_threshold':minimum_threshold,'mew':mew,'mec':mec},levels,cmap,domain,plot_all_dots,ax=ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax is not None or return_ax == True: return plot_ax
+        return plot_ax

--- a/src/tropycal/rain/dataset.py
+++ b/src/tropycal/rain/dataset.py
@@ -193,7 +193,7 @@ class RainDataset():
             self.plot_obj = RainPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             if max(storm['lon']) > 150 or min(storm['lon']) < -150:
                 self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
             else:
@@ -205,7 +205,7 @@ class RainDataset():
         plot_ax = self.plot_obj.plot_storm(storm,grid,levels,cmap,domain,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax != None or return_ax == True: return plot_ax
+        if ax is not None or return_ax == True: return plot_ax
 
     def plot_rain(self,storm,ms=7.5,mec=None,mew=0.5,minimum_threshold=1.0,levels=None,cmap=None,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
@@ -262,7 +262,7 @@ class RainDataset():
             self.plot_obj = RainPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             if max(storm['lon']) > 150 or min(storm['lon']) < -150:
                 self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
             else:
@@ -274,4 +274,4 @@ class RainDataset():
         plot_ax = self.plot_obj.plot_storm(storm,{'ms':ms,'minimum_threshold':minimum_threshold,'mew':mew,'mec':mec},levels,cmap,domain,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax != None or return_ax == True: return plot_ax
+        if ax is not None or return_ax == True: return plot_ax

--- a/src/tropycal/rain/dataset.py
+++ b/src/tropycal/rain/dataset.py
@@ -21,8 +21,6 @@ except:
 
 from .plot import RainPlot
 
-#Import tools
-#from .tools import *
 from ..utils import *
 
 class RainDataset():

--- a/src/tropycal/rain/dataset.py
+++ b/src/tropycal/rain/dataset.py
@@ -17,8 +17,7 @@ try:
     from cartopy import crs as ccrs
     from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
 except:
-    warn_message = "Warning: Cartopy is not installed in your python environment. Plotting functions will not work."
-    warnings.warn(warn_message)
+    warnings.warn("Warning: Cartopy is not installed in your python environment. Plotting functions will not work.")
 
 from .plot import RainPlot
 

--- a/src/tropycal/rain/dataset.py
+++ b/src/tropycal/rain/dataset.py
@@ -267,13 +267,12 @@ class RainDataset():
             self.plot_obj = RainPlot()
         
         #Create cartopy projection
-        if cartopy_proj is None:
-            if max(storm['lon']) > 150 or min(storm['lon']) < -150:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
-            else:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
-        else:
+        if cartopy_proj is not None:
             self.plot_obj.proj = cartopy_proj
+        elif max(storm['lon']) > 150 or min(storm['lon']) < -150:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
+        else:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
         plot_ax = self.plot_obj.plot_storm(storm,{'ms':ms,'minimum_threshold':minimum_threshold,'mew':mew,'mec':mec},levels,cmap,domain,plot_all_dots,ax=ax,save_path=save_path,prop=prop,map_prop=map_prop)

--- a/src/tropycal/rain/dataset.py
+++ b/src/tropycal/rain/dataset.py
@@ -1,0 +1,283 @@
+r"""Functionality for reading and analyzing SPC tornado dataset."""
+
+import numpy as np
+import pandas as pd
+from datetime import datetime as dt,timedelta
+from scipy.interpolate import griddata
+import matplotlib.dates as mdates
+import warnings
+
+import matplotlib.pyplot as plt
+import matplotlib.lines as mlines
+import matplotlib.colors as mcolors
+import matplotlib.patheffects as patheffects
+
+try:
+    import cartopy.feature as cfeature
+    from cartopy import crs as ccrs
+    from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+except:
+    warn_message = "Warning: Cartopy is not installed in your python environment. Plotting functions will not work."
+    warnings.warn(warn_message)
+
+from .plot import RainPlot
+
+#Import tools
+#from .tools import *
+from ..utils import *
+
+class RainDataset():
+    
+    r"""
+    Creates an instance of a RainDataset object containing tropical cyclone rainfall data, courtesy of the Weather Prediction Center (WPC).
+
+    Parameters
+    ----------
+    data_path : str
+        Source to read tropical cyclone rainfall data from. Default is "wpc", which reads from the online Weather Prediction Center (WPC) database. Can change this to a local file.
+
+    Returns
+    -------
+    RainDataset
+        An instance of RainDataset.
+    """
+
+    def __init__(self, data_path='wpc'):
+
+        #Start timer
+        timer_start = dt.now()
+        print(f'--> Starting to read in rainfall data')
+        
+        #Read in storm rainfall dataset
+        if data_path == 'wpc':
+            data_path = "https://www.wpc.ncep.noaa.gov/tropical/rain/CONUS_rainfall_obs_1900-2020.csv"
+        self.rain_df = pd.read_csv("https://www.wpc.ncep.noaa.gov/tropical/rain/CONUS_rainfall_obs_1900-2020.csv")
+
+        #Update user on duration
+        print(f'--> Completed reading in rainfall data (%.2f seconds)' % (dt.now()-timer_start).total_seconds())
+        
+    def get_storm_rainfall(self,storm):
+        
+        r"""
+        Retrieves all rainfall observations in inches associated with a tropical cyclone.
+        
+        Parameters
+        ----------
+        storm : tropycal.tracks.Storm
+            Instance of a Storm object.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Pandas DataFrame object containing rainfall data associated with this tropical cyclone, in inches.
+        """
+        
+        #Filter dataset to this specific storm
+        name_1 = f"{storm.name.title()} {storm.year}"
+        name_2 = f"{storm.id} {storm.year}"
+        df_storm = self.rain_df.loc[(self.rain_df['Storm'] == name_1) | (self.rain_df['Storm'] == name_2)]
+
+        #Drop Storm and Year column, no longer necessary
+        df_storm = df_storm.drop(columns=['Storm','Year'])
+        
+        #Remove NaN entries
+        df_storm = df_storm.loc[~np.isnan(df_storm['Lat'])]
+        df_storm = df_storm.loc[~np.isnan(df_storm['Lon'])]
+        df_storm = df_storm.loc[~np.isnan(df_storm['Total'])]
+        
+        #Check if data is empty
+        if len(df_storm) == 0:
+            msg = "No rainfall data is available for this storm."
+            raise RuntimeError(msg)
+        
+        #Return dataframe
+        return df_storm
+    
+    def interpolate_to_grid(self,storm,grid_res=0.1,method='linear',return_xarray=False):
+        
+        r"""
+        Interpolates storm rainfall data to a horizontal grid.
+        
+        Interpolation is performed using Scipy's `scipy.interpolate.griddata()` interpolation function.
+        
+        Parameters
+        ----------
+        storm : tropycal.tracks.Storm
+            Instance of a Storm object.
+        grid_res : int or float
+            Horizontal resolution of the desired grid in degrees. Default is 0.1 degrees.
+        method : str
+            Method for interpolation to pass to scipy's interpolation function. Default is "linear".
+        return_xarray : bool
+            If True, output is returned as an xarray DataArray with coordinates included. Default is false.
+            
+        Returns
+        -------
+        dict or xarray.DataArray
+            If return_xarray is True, an xarray DataArray is returned. Otherwise, a dict including the grid lat, lon and grid values is returned.
+        """
+        
+        #Check if xarray is installed
+        try:
+            import xarray as xr
+        except ImportError as e:
+            return_xarray = False
+            msg = "xarray is not installed in your python environment. Defaulting to return_xarray=False."
+            warnings.warn(msg)
+        
+        #Check if Storm object contains rainfall data
+        try:
+            storm.rain
+        except:
+            storm.rain = self.get_storm_rainfall(storm)
+        
+        #Create grid to interpolate observations to
+        grid_lon = np.arange(-140,-60+grid_res,grid_res)
+        grid_lat = np.arange(20,50+grid_res,grid_res)
+        
+        #Retrieve data for interpolation
+        rainfall = storm.rain['Total'].values
+        lat = storm.rain['Lat'].values
+        lon = storm.rain['Lon'].values
+
+        #Perform the interpolation
+        grid = griddata((lat, lon), rainfall, (grid_lat[None,:], grid_lon[:,None]), method=method)
+        grid = np.transpose(grid)
+
+        #Return data
+        if return_xarray == False:
+            return {'grid':grid,'lat':grid_lat,'lon':grid_lon}
+        else:
+            return xr.DataArray(grid,coords=[grid_lat,grid_lon],dims=['lat','lon'])
+
+    def plot_rain_grid(self,storm,grid,levels=None,cmap=None,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+        
+        r"""
+        Creates a plot of a storm track and its associated rainfall (gridded).
+        
+        Parameters
+        ----------
+        storm : tropycal.tracks.Storm
+            Storm object to be plotted.
+        grid : dict or xarray.DataArray
+            Output from `interpolate_to_grid()` to be plotted. Can also be any dict with "lat", "lon" and "grid" entries, or an xarray DataArray with "lat" and "lon" dimensions.
+        levels : list or numpy.ndarray
+            List of contour fill levels to plot the grid values, in inches. If none, this is automatically generated.
+        cmap : colormap
+            Colormap to use for contour filling rainfall. If none, this is automatically generated.
+        domain : str
+            Domain for the plot. Default is "dynamic". Please refer to :ref:`options-domain` for available domain options.
+        plot_all_dots : bool
+            Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
+        ax : axes
+            Instance of axes to plot on. If none, one will be generated. Default is none.
+        return_ax : bool
+            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
+        cartopy_proj : ccrs
+            Instance of a cartopy projection to use. If none, one will be generated. Default is none.
+        save_path : str
+            Relative or full path of directory to save the image in. If none, image will not be saved.
+        
+        Other Parameters
+        ----------------
+        prop : dict
+            Customization properties of storm track lines. Please refer to :ref:`options-prop` for available options.
+        map_prop : dict
+            Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        """
+        
+        #Check if Storm object contains rainfall data
+        try:
+            storm.rain
+        except:
+            storm.rain = self.get_storm_rainfall(storm)
+        
+        #Create instance of plot object
+        try:
+            self.plot_obj
+        except:
+            self.plot_obj = RainPlot()
+        
+        #Create cartopy projection
+        if cartopy_proj == None:
+            if max(storm['lon']) > 150 or min(storm['lon']) < -150:
+                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
+            else:
+                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
+        else:
+            self.plot_obj.proj = cartopy_proj
+            
+        #Plot storm
+        plot_ax = self.plot_obj.plot_storm(storm,grid,levels,cmap,domain,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        
+        #Return axis
+        if ax != None or return_ax == True: return plot_ax
+
+    def plot_rain(self,storm,ms=7.5,mec=None,mew=0.5,minimum_threshold=1.0,levels=None,cmap=None,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+        
+        r"""
+        Creates a plot of a storm track and its associated rainfall (individual dots).
+        
+        Parameters
+        ----------
+        storm : tropycal.tracks.Storm
+            Storm object to be plotted.
+        ms : float or int
+            Marker size for individual rainfall observations. Default is 7.5.
+        mec : str or rgb tuple
+            Marker edge color for dots. If none (default), none will be colored.
+        mew : float or int
+            Marker edge width for dots. If mec is specified, the default is 0.5.
+        minimum_threshold : float or int
+            Minimum threshold (in inches) to plot dots. Default is 1.00 inch.
+        levels : list or numpy.ndarray
+            List of levels, in inches, corresponding to the colormap used to color fill the observation dots. If none, this is automatically generated.
+        cmap : colormap
+            Colormap to use for color filling the observation dots. If none, this is automatically generated.
+        domain : str
+            Domain for the plot. Default is "dynamic". Please refer to :ref:`options-domain` for available domain options.
+        plot_all_dots : bool
+            Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
+        ax : axes
+            Instance of axes to plot on. If none, one will be generated. Default is none.
+        return_ax : bool
+            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
+        cartopy_proj : ccrs
+            Instance of a cartopy projection to use. If none, one will be generated. Default is none.
+        save_path : str
+            Relative or full path of directory to save the image in. If none, image will not be saved.
+        
+        Other Parameters
+        ----------------
+        prop : dict
+            Customization properties of storm track lines. Please refer to :ref:`options-prop` for available options.
+        map_prop : dict
+            Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        """
+        
+        #Check if Storm object contains rainfall data
+        try:
+            storm.rain
+        except:
+            storm.rain = self.get_storm_rainfall(storm)
+        
+        #Create instance of plot object
+        try:
+            self.plot_obj
+        except:
+            self.plot_obj = RainPlot()
+        
+        #Create cartopy projection
+        if cartopy_proj == None:
+            if max(storm['lon']) > 150 or min(storm['lon']) < -150:
+                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
+            else:
+                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
+        else:
+            self.plot_obj.proj = cartopy_proj
+            
+        #Plot storm
+        plot_ax = self.plot_obj.plot_storm(storm,{'ms':ms,'minimum_threshold':minimum_threshold,'mew':mew,'mec':mec},levels,cmap,domain,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        
+        #Return axis
+        if ax != None or return_ax == True: return plot_ax

--- a/src/tropycal/rain/dataset.py
+++ b/src/tropycal/rain/dataset.py
@@ -193,13 +193,12 @@ class RainDataset():
             self.plot_obj = RainPlot()
         
         #Create cartopy projection
-        if cartopy_proj is None:
-            if max(storm['lon']) > 150 or min(storm['lon']) < -150:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
-            else:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
-        else:
+        if cartopy_proj is not None:
             self.plot_obj.proj = cartopy_proj
+        elif max(storm['lon']) > 150 or min(storm['lon']) < -150:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
+        else:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
         plot_ax = self.plot_obj.plot_storm(storm,grid,levels,cmap,domain,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)

--- a/src/tropycal/rain/dataset.py
+++ b/src/tropycal/rain/dataset.py
@@ -139,10 +139,10 @@ class RainDataset():
         grid = np.transpose(grid)
 
         #Return data
-        if return_xarray == False:
-            return {'grid':grid,'lat':grid_lat,'lon':grid_lon}
-        else:
+        if return_xarray:
             return xr.DataArray(grid,coords=[grid_lat,grid_lon],dims=['lat','lon'])
+        else:
+            return {'grid':grid,'lat':grid_lat,'lon':grid_lon}
 
     def plot_rain_grid(self,storm,grid,levels=None,cmap=None,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         

--- a/src/tropycal/rain/plot.py
+++ b/src/tropycal/rain/plot.py
@@ -114,9 +114,9 @@ class RainPlot(Plot):
             grid_val = grid.values
         
         #Determine levels and colormap
-        if levels == None:
+        if levels is None:
             levels = [1,2,3,4,6,8,10,12,16,20]
-        if cmap == None:
+        if cmap is None:
             cmap = plt.cm.YlGn
         norm = col.BoundaryNorm(levels,cmap.N)
         
@@ -138,7 +138,7 @@ class RainPlot(Plot):
                 
                 #Specify additional kwargs
                 ms_kwargs = {}
-                if mec != None: ms_kwargs = {'mec':mec,'mew':mew}
+                if mec is not None: ms_kwargs = {'mec':mec,'mew':mew}
                 self.ax.plot(row['Lon'],row['Lat'],'o',ms=ms,color=color,**ms_kwargs,transform=ccrs.PlateCarree())
         
         #Produce colorbar
@@ -501,11 +501,11 @@ class RainPlot(Plot):
         #-----------------------------------------------------------------------------------------
         
         #Save image if specified
-        if save_path != None and isinstance(save_path,str) == True:
+        if save_path is not None and isinstance(save_path,str) == True:
             plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
-        if ax != None or return_ax == True:
+        if ax is not None or return_ax == True:
             return self.ax
         else:
             plt.show()

--- a/src/tropycal/rain/plot.py
+++ b/src/tropycal/rain/plot.py
@@ -36,7 +36,7 @@ class RainPlot(Plot):
         
         self.use_credit = True
     
-    def plot_storm(self,storm,grid,levels,cmap,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,track_labels=False,save_path=None,prop={},map_prop={}):
+    def plot_storm(self,storm,grid,levels,cmap,domain="dynamic",plot_all_dots=False,ax=None,track_labels=False,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single storm track.
@@ -55,8 +55,6 @@ class RainPlot(Plot):
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            Whether to return axis at the end of the function. If false, plot will be displayed on the screen. Default is false.
         prop : dict
             Property of storm track lines.
         map_prop : dict
@@ -503,8 +501,4 @@ class RainPlot(Plot):
             plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
-        if ax is not None or return_ax == True:
-            return self.ax
-        else:
-            plt.show()
-            plt.close()
+        return self.ax

--- a/src/tropycal/rain/plot.py
+++ b/src/tropycal/rain/plot.py
@@ -1,0 +1,512 @@
+import calendar
+import numpy as np
+import pandas as pd
+import re
+import scipy.interpolate as interp
+import urllib
+import warnings
+from datetime import datetime as dt,timedelta
+
+from ..plot import Plot
+
+#Import tools
+#from .tools import *
+from ..utils import *
+
+try:
+    import cartopy.feature as cfeature
+    from cartopy import crs as ccrs
+    from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+except:
+    warnings.warn("Warning: Cartopy is not installed in your python environment. Plotting functions will not work.")
+
+try:
+    import matplotlib as mlib
+    import matplotlib.lines as mlines
+    import matplotlib.patheffects as path_effects
+    import matplotlib.pyplot as plt
+    import matplotlib.colors as col
+    import matplotlib.ticker as mticker
+    import matplotlib.patches as mpatches
+
+except:
+    warnings.warn("Warning: Matplotlib is not installed in your python environment. Plotting functions will not work.")
+
+class RainPlot(Plot):
+    
+    def __init__(self):
+        
+        self.use_credit = True
+    
+    def plot_storm(self,storm,grid,levels,cmap,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,track_labels=False,save_path=None,prop={},map_prop={}):
+        
+        r"""
+        Creates a plot of a single storm track.
+        
+        Parameters
+        ----------
+        storm : str, tuple or dict
+            Requested storm. Can be either string of storm ID (e.g., "AL052019"), tuple with storm name and year (e.g., ("Matthew",2016)), or a dict entry.
+        domain : str
+            Domain for the plot. Can be one of the following:
+            "dynamic" - default. Dynamically focuses the domain using the storm track(s) plotted.
+            "north_atlantic" - North Atlantic Ocean basin
+            "pacific" - East/Central Pacific Ocean basin
+            "lonW/lonE/latS/latN" - Custom plot domain
+        plot_all_dots : bool
+            Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
+        ax : axes
+            Instance of axes to plot on. If none, one will be generated. Default is none.
+        return_ax : bool
+            Whether to return axis at the end of the function. If false, plot will be displayed on the screen. Default is false.
+        prop : dict
+            Property of storm track lines.
+        map_prop : dict
+            Property of cartopy map.
+        """
+        
+        #Set default properties
+        default_prop={'dots':True,'fillcolor':'category','cmap':None,'levels':None,'linecolor':'k','linewidth':1.0,'ms':7.5}
+        default_map_prop={'res':'m','land_color':'#FBF5EA','ocean_color':'#EDFBFF','linewidth':0.5,'linecolor':'k','figsize':(14,9),'dpi':200}
+        
+        #Initialize plot
+        prop = self.add_prop(prop,default_prop)
+        map_prop = self.add_prop(map_prop,default_map_prop)
+        self.plot_init(ax,map_prop,plot_geography=False)
+        
+        #--------------------------------------------------------------------------------------
+        
+        #get resolution corresponding to string in prop
+        res = self.check_res(map_prop['res'])
+        
+        #fill oceans if specified
+        self.ax.set_facecolor(map_prop['ocean_color'])
+        ocean_mask = self.ax.add_feature(cfeature.OCEAN.with_scale(res),facecolor=map_prop['ocean_color'],edgecolor='face',zorder=3)
+        lake_mask = self.ax.add_feature(cfeature.LAKES.with_scale(res),facecolor=map_prop['ocean_color'],edgecolor='face',zorder=1)
+        continent_mask = self.ax.add_feature(cfeature.LAND.with_scale(res),facecolor=map_prop['land_color'],edgecolor='face',zorder=0)
+        
+        #draw geography
+        states = self.ax.add_feature(cfeature.STATES.with_scale(res),linewidths=map_prop['linewidth'],
+                                     linestyle='solid',edgecolor=map_prop['linecolor'],zorder=4)
+        countries = self.ax.add_feature(cfeature.BORDERS.with_scale(res),linewidths=map_prop['linewidth'],
+                                        linestyle='solid',edgecolor=map_prop['linecolor'],zorder=4)
+        coastlines = self.ax.add_feature(cfeature.COASTLINE.with_scale(res),linewidths=map_prop['linewidth'],
+                                         linestyle='solid',edgecolor=map_prop['linecolor'],zorder=4)
+        
+        #--------------------------------------------------------------------------------------
+        
+        #Retrieve grid coordinates and values
+        plot_grid = True
+        if isinstance(grid,dict) == True:
+            if 'lat' in grid.keys():
+                grid_lat = grid['lat']
+                grid_lon = grid['lon']
+                grid_val = grid['grid']
+            else:
+                ms = grid['ms']
+                mec = grid['mec']
+                mew = grid['mew']
+                minimum_threshold = grid['minimum_threshold']
+                plot_grid = False
+        else:
+            grid_lat = grid.lat.values
+            grid_lon = grid.lon.values
+            grid_val = grid.values
+        
+        #Determine levels and colormap
+        if levels == None:
+            levels = [1,2,3,4,6,8,10,12,16,20]
+        if cmap == None:
+            cmap = plt.cm.YlGn
+        norm = col.BoundaryNorm(levels,cmap.N)
+        
+        #Contour fill grid if requested
+        if plot_grid == True:
+            self.ax.contourf(grid_lon, grid_lat, grid, levels, cmap=cmap, norm=norm, zorder=2)
+        
+        #Plot dots if requested
+        else:
+            
+            #Iterate over sorted data (so highest totals show up on top)
+            iter_df = storm.rain.sort_values('Total')
+            for _,row in iter_df.iterrows():
+                
+                #Retrieve rain total and determine color
+                rain_value = row['Total']
+                if rain_value < minimum_threshold: continue
+                color = self.rgb(cmap(norm(rain_value),bytes=True)[:-1])
+                
+                #Specify additional kwargs
+                ms_kwargs = {}
+                if mec != None: ms_kwargs = {'mec':mec,'mew':mew}
+                self.ax.plot(row['Lon'],row['Lat'],'o',ms=ms,color=color,**ms_kwargs,transform=ccrs.PlateCarree())
+        
+        #Produce colorbar
+        cs = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+        cs.set_array([])
+        self.fig.colorbar(cs,ax=self.ax)
+        
+        #--------------------------------------------------------------------------------------
+        
+        #Keep record of lat/lon coordinate extrema
+        max_lat = np.nanmax(storm.rain['Lat'].values)
+        min_lat = np.nanmin(storm.rain['Lat'].values)
+        max_lon = np.nanmax(storm.rain['Lon'].values)
+        min_lon = np.nanmin(storm.rain['Lon'].values)
+
+        #Get storm data
+        storm_data = storm.dict
+
+        #Retrieve storm data
+        lats = storm_data['lat']
+        lons = storm_data['lon']
+        vmax = storm_data['vmax']
+        styp = storm_data['type']
+        sdate = storm_data['date']
+                
+        #Account for cases crossing dateline
+        if self.proj.proj4_params['lon_0'] == 180.0:
+            new_lons = np.array(lons)
+            new_lons[new_lons<0] = new_lons[new_lons<0]+360.0
+            lons = new_lons.tolist()
+
+        #Force dynamic_tropical to tropical if an invest
+        invest_bool = False
+        if 'invest' in storm_data.keys() and storm_data['invest'] == True:
+            invest_bool = True
+            if domain == 'dynamic_tropical': domain = 'dynamic'
+        
+        #Add to coordinate extrema
+        if domain == 'dynamic_tropical':
+            type_array = np.array(storm_data['type'])
+            idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))
+            use_lats = (np.array(storm_data['lat'])[idx]).tolist()
+            use_lons = (np.array(lons)[idx]).tolist()
+        else:
+            use_lats = storm_data['lat']
+            use_lons = np.copy(lons).tolist()
+
+        #Iterate over storm data to plot
+        for i,(i_lat,i_lon,i_vmax,i_mslp,i_date,i_type) in enumerate(zip(storm_data['lat'],lons,storm_data['vmax'],storm_data['mslp'],storm_data['date'],storm_data['type'])):
+
+            #Determine line color, with SSHWS scale used as default
+            if prop['linecolor'] == 'category':
+                segmented_colors = True
+                line_color = get_colors_sshws(np.nan_to_num(i_vmax))
+
+            #Use user-defined colormap if another storm variable
+            elif isinstance(prop['linecolor'],str) == True and prop['linecolor'] in ['vmax','mslp']:
+                segmented_colors = True
+                color_variable = storm_data[prop['linecolor']]
+                if prop['levels'] is None: #Auto-determine color levels if needed
+                    prop['levels'] = [np.nanmin(color_variable),np.nanmax(color_variable)]
+                cmap,levels = get_cmap_levels(prop['linecolor'],prop['cmap'],prop['levels'])
+                line_color = cmap((color_variable-min(levels))/(max(levels)-min(levels)))[i]
+
+            #Otherwise go with user input as is
+            else:
+                segmented_colors = False
+                line_color = prop['linecolor']
+
+            #For tropical/subtropical types, color-code if requested
+            if i > 0:
+                if i_type in ['SD','TD','SS','TS','HU']:
+
+                    #Plot underlying black and overlying colored line
+                    self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],'-',
+                                  linewidth=prop['linewidth']*1.33,color='k',zorder=5,
+                                  transform=ccrs.PlateCarree())
+                    self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],'-',
+                                  linewidth=prop['linewidth'],color=line_color,zorder=6,
+                                  transform=ccrs.PlateCarree())
+
+                #For non-tropical types, plot dotted lines
+                else:
+
+                    #Restrict line width to 1.5 max
+                    line_width = prop['linewidth'] + 0.0
+                    if line_width > 1.5: line_width = 1.5
+
+                    #Plot dotted line
+                    self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],':',
+                                  linewidth=line_width,color=line_color,zorder=6,
+                                  transform=ccrs.PlateCarree(),
+                                  path_effects=[path_effects.Stroke(linewidth=line_width*1.33, foreground='k'),
+                                                path_effects.Normal()])
+
+            #Plot dots if requested
+            if prop['dots'] == True:
+                
+                #Skip if plot_all_dots == False and not in 0,6,12,18z
+                if plot_all_dots == False:
+                    if i_date.strftime('%H%M') not in ['0000','0600','1200','1800']: continue
+
+                #Determine fill color, with SSHWS scale used as default
+                if prop['fillcolor'] == 'category':
+                    segmented_colors = True
+                    fill_color = get_colors_sshws(np.nan_to_num(i_vmax))
+
+                #Use user-defined colormap if another storm variable
+                elif isinstance(prop['fillcolor'],str) == True and prop['fillcolor'] in ['vmax','mslp']:
+                    segmented_colors = True
+                    color_variable = storm_data[prop['fillcolor']]
+                    if prop['levels'] is None: #Auto-determine color levels if needed
+                        prop['levels'] = [np.nanmin(color_variable),np.nanmax(color_variable)]
+                    cmap,levels = get_cmap_levels(prop['fillcolor'],prop['cmap'],prop['levels'])
+                    fill_color = cmap((color_variable-min(levels))/(max(levels)-min(levels)))[i]
+
+                #Otherwise go with user input as is
+                else:
+                    segmented_colors = False
+                    fill_color = prop['fillcolor']
+
+                #Determine dot type
+                marker_type = '^'
+                if i_type in ['SD','SS']:
+                    marker_type = 's'
+                elif i_type in ['TD','TS','HU']:
+                    marker_type = 'o'
+
+                #Plot marker
+                self.ax.plot(i_lon,i_lat,marker_type,mfc=fill_color,mec='k',mew=0.5,
+                             zorder=7,ms=prop['ms'],transform=ccrs.PlateCarree())
+
+            #Label track dots
+            if track_labels in ['valid_utc']:
+                if track_labels == 'valid_utc':
+                    strformat = '%H UTC \n%-m/%-d'
+                    labels = {t.strftime(strformat):(x,y) for t,x,y in zip(sdate,lons,lats) if t.hour==0}
+                    track = {t.strftime(strformat):(x,y) for t,x,y in zip(sdate,lons,lats)}
+                self.plot_track_labels(self.ax, labels, track, k=.9)
+
+        #--------------------------------------------------------------------------------------
+        
+        #Storm-centered plot domain
+        if domain == "dynamic" or domain == "dynamic_tropical":
+            
+            bound_w,bound_e,bound_s,bound_n = self.dynamic_map_extent(min_lon,max_lon,min_lat,max_lat)
+            self.ax.set_extent([bound_w,bound_e,bound_s,bound_n], crs=ccrs.PlateCarree())
+            
+        #Pre-generated or custom domain
+        else:
+            bound_w,bound_e,bound_s,bound_n = self.set_projection(domain)
+
+        #Plot parallels and meridians
+        #This is currently not supported for all cartopy projections.
+        try:
+            self.plot_lat_lon_lines([bound_w,bound_e,bound_s,bound_n],zorder=9)
+        except:
+            pass
+        
+        #--------------------------------------------------------------------------------------
+        
+        #Add left title
+        type_array = np.array(storm_data['type'])
+        if invest_bool == False:
+            idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))
+            tropical_vmax = np.array(storm_data['vmax'])[idx]
+            
+            #Coerce to include non-TC points if storm hasn't been designated yet
+            add_ptc_flag = False
+            if len(tropical_vmax) == 0:
+                add_ptc_flag = True
+                idx = np.where((type_array == 'LO') | (type_array == 'DB'))
+            tropical_vmax = np.array(storm_data['vmax'])[idx]
+
+            subtrop = classify_subtropical(np.array(storm_data['type']))
+            peak_idx = storm_data['vmax'].index(np.nanmax(tropical_vmax))
+            peak_basin = storm_data['wmo_basin'][peak_idx]
+            storm_type = get_storm_classification(np.nanmax(tropical_vmax),subtrop,peak_basin)
+            if add_ptc_flag == True: storm_type = "Potential Tropical Cyclone"
+            left_title_string = f"{storm_type} {storm_data['name']}"
+        else:
+            #Use all indices for invests
+            idx = np.array([True for i in type_array])
+            add_ptc_flag = False
+            tropical_vmax = np.array(storm_data['vmax'])
+            
+            #Determine letter in front of invest
+            add_letter = 'L'
+            if storm_data['id'][0] == 'C':
+                add_letter = 'C'
+            elif storm_data['id'][0] == 'E':
+                add_letter = 'E'
+            
+            #Add title
+            left_title_string = f"INVEST {storm_data['id'][2:4]}{add_letter}"
+
+        #Add left title
+        if plot_grid == True:
+            left_title_string += "\nInterpolated WPC Storm Rainfall (in)"
+        else:
+            if minimum_threshold > 1:
+                left_title_string += f"\nWPC Storm Rainfall (>{np.round(minimum_threshold,2)} inch)"
+            else:
+                left_title_string += f"\nWPC Storm Rainfall (inch)"
+        self.ax.set_title(left_title_string,loc='left',fontsize=16,fontweight='bold')
+        
+        #Add right title
+        ace = storm_data['ace']
+        if add_ptc_flag == True: ace = 0.0
+        type_array = np.array(storm_data['type'])
+        
+        #Get storm extrema for display
+        mslp_key = 'mslp' if 'wmo_mslp' not in storm_data.keys() else 'wmo_mslp'
+        if all_nan(np.array(storm_data[mslp_key])[idx]) == True:
+            min_pres = "N/A"
+        else:
+            min_pres = int(np.nan_to_num(np.nanmin(np.array(storm_data[mslp_key])[idx])))
+        if all_nan(np.array(storm_data['vmax'])[idx]) == True:
+            max_wind = "N/A"
+        else:
+            max_wind = int(np.nan_to_num(np.nanmax(np.array(storm_data['vmax'])[idx])))
+        start_date = dt.strftime(np.array(storm_data['date'])[idx][0],'%d %b %Y')
+        end_date = dt.strftime(np.array(storm_data['date'])[idx][-1],'%d %b %Y')
+        endash = u"\u2013"
+        dot = u"\u2022"
+        self.ax.set_title(f"{start_date} {endash} {end_date}\n{max_wind} kt {dot} {min_pres} hPa {dot} {ace:.1f} ACE",loc='right',fontsize=13)
+
+        #--------------------------------------------------------------------------------------
+        
+        #Add plot credit
+        warning_text=""
+        if storm_data['source'] == 'ibtracs' and storm_data['source_info'] == 'World Meteorological Organization (official)':
+            warning_text = f"This plot uses 10-minute averaged WMO official wind data converted\nto 1-minute average (factor of 0.88). Use this wind data with caution.\n\n"
+
+            self.ax.text(0.99,0.01,warning_text,fontsize=9,color='k',alpha=0.7,
+            transform=self.ax.transAxes,ha='right',va='bottom',zorder=10)
+        
+        credit_text = "Rainfall data (inch) from\nWeather Prediction Center (WPC)\n\n"
+        self.ax.text(0.99,0.01,credit_text,fontsize=9,color='k',alpha=0.7,
+                     transform=self.ax.transAxes,ha='right',va='bottom',zorder=10)
+        
+        credit_text = self.plot_credit()
+        self.add_credit(credit_text)
+        
+        #--------------------------------------------------------------------------------------
+                
+        #Add legend
+        if prop['fillcolor'] == 'category' and prop['dots'] == True:
+            ex = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Non-Tropical', marker='^', color='w')
+            sb = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Subtropical', marker='s', color='w')
+            td = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Tropical Depression', marker='o', color=get_colors_sshws(33))
+            ts = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Tropical Storm', marker='o', color=get_colors_sshws(34))
+            c1 = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Category 1', marker='o', color=get_colors_sshws(64))
+            c2 = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Category 2', marker='o', color=get_colors_sshws(83))
+            c3 = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Category 3', marker='o', color=get_colors_sshws(96))
+            c4 = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Category 4', marker='o', color=get_colors_sshws(113))
+            c5 = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Category 5', marker='o', color=get_colors_sshws(137))
+            self.ax.legend(handles=[ex,sb,td,ts,c1,c2,c3,c4,c5], prop={'size':11.5})
+
+        elif prop['linecolor'] == 'category' and prop['dots'] == False:
+            ex = mlines.Line2D([], [], linestyle='dotted', label='Non-Tropical', color='k')
+            td = mlines.Line2D([], [], linestyle='solid', label='Sub/Tropical Depression', color=get_colors_sshws(33))
+            ts = mlines.Line2D([], [], linestyle='solid', label='Sub/Tropical Storm', color=get_colors_sshws(34))
+            c1 = mlines.Line2D([], [], linestyle='solid', label='Category 1', color=get_colors_sshws(64))
+            c2 = mlines.Line2D([], [], linestyle='solid', label='Category 2', color=get_colors_sshws(83))
+            c3 = mlines.Line2D([], [], linestyle='solid', label='Category 3', color=get_colors_sshws(96))
+            c4 = mlines.Line2D([], [], linestyle='solid', label='Category 4', color=get_colors_sshws(113))
+            c5 = mlines.Line2D([], [], linestyle='solid', label='Category 5', color=get_colors_sshws(137))
+            self.ax.legend(handles=[ex,td,ts,c1,c2,c3,c4,c5], prop={'size':11.5}).set_zorder(10)
+
+        elif prop['dots'] and segmented_colors == False:
+            ex = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Non-Tropical', marker='^', color=prop['fillcolor'])
+            sb = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Subtropical', marker='s', color=prop['fillcolor'])
+            td = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Tropical', marker='o', color=prop['fillcolor'])
+            handles=[ex,sb,td]
+            self.ax.legend(handles=handles,fontsize=11.5).set_zorder(10)
+
+        elif prop['dots'] == False and segmented_colors == False:
+            ex = mlines.Line2D([], [], linestyle='dotted',label='Non-Tropical', color=prop['linecolor'])
+            td = mlines.Line2D([], [], linestyle='solid',label='Tropical', color=prop['linecolor'])
+            handles=[ex,td]
+            self.ax.legend(handles=handles,fontsize=11.5).set_zorder(10)
+
+        elif prop['dots'] == True:
+            ex = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Non-Tropical', marker='^', color='w')
+            sb = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Subtropical', marker='s', color='w')
+            td = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Tropical', marker='o', color='w')
+            handles=[ex,sb,td]
+            for _ in range(7):
+                handles.append(mlines.Line2D([], [], linestyle='-',label='',lw=0))
+            l=self.ax.legend(handles=handles,fontsize=11.5).set_zorder(10)
+            plt.draw()
+            
+            #Get the bbox
+            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+                
+            #Define colorbar axis
+            cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
+            norm = mlib.colors.Normalize(vmin=min(levels), vmax=max(levels))
+            cbmap = mlib.cm.ScalarMappable(norm=norm, cmap=cmap)
+            cbar = self.fig.colorbar(cbmap,cax=cax,orientation='vertical',\
+                                     ticks=levels)
+            
+            cax.tick_params(labelsize=11.5)
+            cax.yaxis.set_ticks_position('left')
+            cbar.set_label(prop['fillcolor'],fontsize=11.5,rotation=90)
+        
+            rect_offset = 0.0
+            if prop['cmap'] == 'category' and prop['fillcolor'] == 'vmax':
+                cax.yaxis.set_ticks(np.linspace(min(levels),max(levels),len(levels)))
+                cax.yaxis.set_ticklabels(levels)
+                cax2 = cax.twinx()
+                cax2.yaxis.set_ticks_position('right')
+                cax2.yaxis.set_ticks((np.linspace(0,1,len(levels))[:-1]+np.linspace(0,1,len(levels))[1:])*.5)
+                cax2.set_yticklabels(['TD','TS','Cat-1','Cat-2','Cat-3','Cat-4','Cat-5'],fontsize=11.5)
+                cax2.tick_params('both', length=0, width=0, which='major')
+                cax.yaxis.set_ticks_position('left')
+                rect_offset = 0.7
+            if prop['fillcolor'] == 'date':
+                cax.set_yticklabels([f'{mdates.num2date(i):%b %-d}' for i in clevs],fontsize=11.5)
+                
+        else:
+            ex = mlines.Line2D([], [], linestyle='dotted',label='Non-Tropical', color='k')
+            td = mlines.Line2D([], [], linestyle='solid',label='Tropical', color='k')
+            handles=[ex,td]
+            for _ in range(7):
+                handles.append(mlines.Line2D([], [], linestyle='-',label='',lw=0))
+            l=self.ax.legend(handles=handles,fontsize=11.5).set_zorder(10)
+            plt.draw()
+            
+            #Get the bbox
+            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+                
+            #Define colorbar axis
+            cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
+            norm = mlib.colors.Normalize(vmin=min(levels), vmax=max(levels))
+            cbmap = mlib.cm.ScalarMappable(norm=norm, cmap=cmap)
+            cbar = self.fig.colorbar(cbmap,cax=cax,orientation='vertical',\
+                                     ticks=levels)
+            
+            cax.tick_params(labelsize=11.5)
+            cax.yaxis.set_ticks_position('left')
+            cbarlab = make_var_label(prop['linecolor'],storm_data)            
+            cbar.set_label(cbarlab,fontsize=11.5,rotation=90)
+        
+            rect_offset = 0.0
+            if prop['cmap'] == 'category' and prop['linecolor'] == 'vmax':
+                cax.yaxis.set_ticks(np.linspace(min(levels),max(levels),len(levels)))
+                cax.yaxis.set_ticklabels(levels)
+                cax2 = cax.twinx()
+                cax2.yaxis.set_ticks_position('right')
+                cax2.yaxis.set_ticks((np.linspace(0,1,len(levels))[:-1]+np.linspace(0,1,len(levels))[1:])*.5)
+                cax2.set_yticklabels(['TD','TS','Cat-1','Cat-2','Cat-3','Cat-4','Cat-5'],fontsize=11.5)
+                cax2.tick_params('both', length=0, width=0, which='major')
+                cax.yaxis.set_ticks_position('left')
+                rect_offset = 0.7
+            if prop['linecolor'] == 'date':
+                cax.set_yticklabels([f'{mdates.num2date(i):%b %-d}' for i in clevs],fontsize=11.5)
+                
+        #-----------------------------------------------------------------------------------------
+        
+        #Save image if specified
+        if save_path != None and isinstance(save_path,str) == True:
+            plt.savefig(save_path,bbox_inches='tight')
+        
+        #Return axis if specified, otherwise display figure
+        if ax != None or return_ax == True:
+            return self.ax
+        else:
+            plt.show()
+            plt.close()

--- a/src/tropycal/rain/plot.py
+++ b/src/tropycal/rain/plot.py
@@ -9,8 +9,6 @@ from datetime import datetime as dt,timedelta
 
 from ..plot import Plot
 
-#Import tools
-#from .tools import *
 from ..utils import *
 
 try:

--- a/src/tropycal/rain/plot.py
+++ b/src/tropycal/rain/plot.py
@@ -93,7 +93,7 @@ class RainPlot(Plot):
         
         #Retrieve grid coordinates and values
         plot_grid = True
-        if isinstance(grid,dict) == True:
+        if isinstance(grid,dict):
             if 'lat' in grid.keys():
                 grid_lat = grid['lat']
                 grid_lon = grid['lon']
@@ -117,7 +117,7 @@ class RainPlot(Plot):
         norm = col.BoundaryNorm(levels,cmap.N)
         
         #Contour fill grid if requested
-        if plot_grid == True:
+        if plot_grid:
             self.ax.contourf(grid_lon, grid_lat, grid, levels, cmap=cmap, norm=norm, zorder=2)
         
         #Plot dots if requested
@@ -168,7 +168,7 @@ class RainPlot(Plot):
 
         #Force dynamic_tropical to tropical if an invest
         invest_bool = False
-        if 'invest' in storm_data.keys() and storm_data['invest'] == True:
+        if 'invest' in storm_data.keys() and storm_data['invest']:
             invest_bool = True
             if domain == 'dynamic_tropical': domain = 'dynamic'
         

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -125,7 +125,7 @@ class Realtime():
         if jtwc_source not in ['ucar','noaa','jtwc']:
             msg = "\"jtwc_source\" must be either \"ucar\", \"noaa\", or \"jtwc\"."
             raise ValueError(msg)
-        if jtwc == True: self.__read_btk_jtwc(jtwc_source)
+        if jtwc: self.__read_btk_jtwc(jtwc_source)
         
         #Determine time elapsed
         time_elapsed = dt.now() - start_time
@@ -219,7 +219,7 @@ class Realtime():
             self.data[stormid]['ace'] = 0.0
 
             #Read in file
-            if use_ftp == True:
+            if use_ftp:
                 url = f"ftp://ftp.nhc.noaa.gov/atcf/btk/{file}"
             else:
                 url = f"https://ftp.nhc.noaa.gov/atcf/btk/{file}"

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -297,7 +297,7 @@ class RealtimeStorm(Storm):
 
                 if len(forecasts) == 0:
                     forecasts = {
-                        'fhr':[],'lat':[],'lon':[],'vmax':[],'mslp':[],'cumulative_ace':[],'type':[],'init':dt.strptime(run_init,'%Y%m%d%H')
+                        'fhr':[],'lat':[],'lon':[],'vmax':[],'mslp':[],'cumulative_ace':[],'cumulative_ace_fhr':[],'type':[],'init':dt.strptime(run_init,'%Y%m%d%H')
                     }
 
                 #Format lat & lon
@@ -377,7 +377,7 @@ class RealtimeStorm(Storm):
                     
                 if len(forecasts) == 0:
                     forecasts = {
-                        'fhr':[],'lat':[],'lon':[],'vmax':[],'mslp':[],'cumulative_ace':[],'type':[],'init':dt.strptime(run_init,'%Y%m%d%H')
+                        'fhr':[],'lat':[],'lon':[],'vmax':[],'mslp':[],'cumulative_ace':[],'cumulative_ace_fhr':[],'type':[],'init':dt.strptime(run_init,'%Y%m%d%H')
                     }
 
                 #Forecast hour
@@ -426,6 +426,7 @@ class RealtimeStorm(Storm):
         
         #Add initial forecast hour ACE
         ace += accumulated_cyclone_energy(forecasts['vmax'][0],hours=6)
+        forecasts['cumulative_ace_fhr'].append(0)
         forecasts['cumulative_ace'].append(np.round(ace,1))
         
         #Interpolate forecast to 6-hour increments
@@ -458,6 +459,7 @@ class RealtimeStorm(Storm):
             #Add ACE to array
             if i_fhr in forecasts['fhr']:
                 forecasts['cumulative_ace'].append(np.round(ace,1))
+                forecasts['cumulative_ace_fhr'].append(i_fhr)
         
         #Save forecast as attribute
         self.latest_forecast = forecasts
@@ -854,7 +856,7 @@ class RealtimeStorm(Storm):
         disco_date = disco_date + timedelta(hours=offset*-1)
         
     def __get_ensembles_eps(self):
-        #Here it is:
+        #This function is currently not functioning. The path to retrieve EPS ensemble data is:
         #ftp://wmo:essential@dissemination.ecmwf.int/20200518120000/
         #A_JSXX01ECEP181200_C_ECMP_20200518120000_tropical_cyclone_track_AMPHAN_86p3degE_14degN_bufr4.bin
         return

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -466,7 +466,7 @@ class RealtimeStorm(Storm):
         return self.latest_forecast
 
     def plot_forecast_realtime(self,track_labels='fhr',cone_days=5,domain="dynamic_forecast",
-                                   ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+                                   ax=None,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Plots the latest available official forecast. Available for both NHC and JTWC sources.
@@ -486,8 +486,6 @@ class RealtimeStorm(Storm):
             Domain for the plot. Default is "dynamic_forecast". Please refer to :ref:`options-domain` for available domain options.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         save_path : str
@@ -496,6 +494,11 @@ class RealtimeStorm(Storm):
             Property of storm track lines.
         map_prop : dict
             Property of cartopy map.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         """
         
         #Check to ensure storm is not an invest
@@ -527,10 +530,10 @@ class RealtimeStorm(Storm):
         if self.source != "hurdat": nhc_forecasts['cone'] = False
         
         #Plot storm
-        plot_ax = self.plot_obj.plot_storm_nhc(nhc_forecasts,self.dict,track_labels,cone_days,domain,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_storm_nhc(nhc_forecasts,self.dict,track_labels,cone_days,domain,ax=ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax is not None or return_ax == True: return plot_ax
+        return plot_ax
         
     def get_realtime_info(self,source='all'):
         

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -61,7 +61,7 @@ class RealtimeStorm(Storm):
         #Format keys for summary
         type_array = np.array(self.dict['type'])
         idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))[0]
-        if self.invest == True: idx = np.array([True for i in type_array])
+        if self.invest: idx = np.array([True for i in type_array])
         if len(idx) == 0:
             start_date = 'N/A'
             end_date = 'N/A'
@@ -128,7 +128,7 @@ class RealtimeStorm(Storm):
                 self[key] = np.array(self.dict[key])
                 
         #Assign tornado data
-        if stormTors is not None and isinstance(stormTors,dict) == True:
+        if stormTors is not None and isinstance(stormTors,dict):
             self.stormTors = stormTors['data']
             self.tornado_dist_thresh = stormTors['dist_thresh']
             self.coords['Tornado Count'] = len(stormTors['data'])
@@ -137,7 +137,7 @@ class RealtimeStorm(Storm):
         self.get_archer()
         
         #Determine if storm object was retrieved via realtime object
-        if 'realtime' in keys and self.dict['realtime'] == True:
+        if 'realtime' in keys and self.dict['realtime']:
             self.realtime = True
             self.coords['realtime'] = True
         else:
@@ -156,7 +156,7 @@ class RealtimeStorm(Storm):
         """
         
         #Check to ensure storm is not an invest
-        if self.invest == True:
+        if self.invest:
             raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Determine data source
@@ -192,7 +192,7 @@ class RealtimeStorm(Storm):
         warnings.warn("'get_nhc_discussion_realtime' will be deprecated in future Tropycal versions, use 'get_discussion_realtime' instead",DeprecationWarning)
         
         #Check to ensure storm is not an invest
-        if self.invest == True:
+        if self.invest:
             raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Get latest forecast discussion for HURDAT source storm objects
@@ -227,7 +227,7 @@ class RealtimeStorm(Storm):
         """
         
         #Check to ensure storm is not an invest
-        if self.invest == True:
+        if self.invest:
             raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Get latest forecast discussion for HURDAT source storm objects
@@ -266,7 +266,7 @@ class RealtimeStorm(Storm):
         """
         
         #Check to ensure storm is not an invest
-        if self.invest == True:
+        if self.invest:
             raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #NHC forecast data
@@ -502,7 +502,7 @@ class RealtimeStorm(Storm):
         """
         
         #Check to ensure storm is not an invest
-        if self.invest == True:
+        if self.invest:
             raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Create instance of plot object
@@ -567,7 +567,7 @@ class RealtimeStorm(Storm):
             raise RuntimeError(msg)
         
         #Check to ensure storm is not an invest
-        if self.invest == True:
+        if self.invest:
             msg = "NHC does not issue public advisories on invests. Defaulting to best track method."
             warnings.warn(msg)
             source = 'best_track'

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -128,7 +128,7 @@ class RealtimeStorm(Storm):
                 self[key] = np.array(self.dict[key])
                 
         #Assign tornado data
-        if stormTors != None and isinstance(stormTors,dict) == True:
+        if stormTors is not None and isinstance(stormTors,dict) == True:
             self.stormTors = stormTors['data']
             self.tornado_dist_thresh = stormTors['dist_thresh']
             self.coords['Tornado Count'] = len(stormTors['data'])
@@ -509,7 +509,7 @@ class RealtimeStorm(Storm):
             self.plot_obj = TrackPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             if max(self.dict['lon']) > 140 or min(self.dict['lon']) < -140:
                 self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
             else:
@@ -530,7 +530,7 @@ class RealtimeStorm(Storm):
         plot_ax = self.plot_obj.plot_storm_nhc(nhc_forecasts,self.dict,track_labels,cone_days,domain,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax != None or return_ax == True: return plot_ax
+        if ax is not None or return_ax == True: return plot_ax
         
     def get_realtime_info(self,source='all'):
         

--- a/src/tropycal/recon/dataset.py
+++ b/src/tropycal/recon/dataset.py
@@ -378,7 +378,7 @@ class ReconDataset:
         self.plot_obj = ReconPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             cartopy_proj = self.plot_obj.proj
         
@@ -387,7 +387,7 @@ class ReconDataset:
                                               ax=ax,return_ax=return_ax,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax != None or return_ax==True:
+        if ax is not None or return_ax==True:
             return plot_info
 
     
@@ -772,7 +772,7 @@ class ReconDataset:
         self.plot_obj = ReconPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             cartopy_proj = self.plot_obj.proj
         
@@ -781,5 +781,5 @@ class ReconDataset:
                                              domain,ax,return_ax,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax != None or return_ax==True:
+        if ax is not None or return_ax==True:
             return plot_info

--- a/src/tropycal/recon/plot.py
+++ b/src/tropycal/recon/plot.py
@@ -108,19 +108,19 @@ class ReconPlot(Plot):
         lons = recon_data['lon']
 
         #Add to coordinate extrema
-        if max_lat == None:
+        if max_lat is None:
             max_lat = max(lats)
         else:
             if max(lats) > max_lat: max_lat = max(lats)
-        if min_lat == None:
+        if min_lat is None:
             min_lat = min(lats)
         else:
             if min(lats) < min_lat: min_lat = min(lats)
-        if max_lon == None:
+        if max_lon is None:
             max_lon = max(lons)
         else:
             if max(lons) > max_lon: max_lon = max(lons)
-        if min_lon == None:
+        if min_lon is None:
             min_lon = min(lons)
         else:
             if min(lons) < min_lon: min_lon = min(lons)
@@ -248,7 +248,7 @@ class ReconPlot(Plot):
         self.add_credit(text)
         
         #Return axis if specified, otherwise display figure
-        if ax != None or return_ax == True:
+        if ax is not None or return_ax == True:
             return self.ax,'/'.join([str(b) for b in [bound_w,bound_e,bound_s,bound_n]])
         else:
             plt.show()
@@ -284,19 +284,19 @@ class ReconPlot(Plot):
         sdate = storm_data['date']
 
         #Add to coordinate extrema
-        if max_lat == None:
+        if max_lat is None:
             max_lat = max(lats)+2.5
         else:
             if max(lats) > max_lat: max_lat = max(lats)
-        if min_lat == None:
+        if min_lat is None:
             min_lat = min(lats)-2.5
         else:
             if min(lats) < min_lat: min_lat = min(lats)
-        if max_lon == None:
+        if max_lon is None:
             max_lon = max(lons)+2.5
         else:
             if max(lons) > max_lon: max_lon = max(lons)
-        if min_lon == None:
+        if min_lon is None:
             min_lon = min(lons)-2.5
         else:
             if min(lons) < min_lon: min_lon = min(lons)      
@@ -458,7 +458,7 @@ class ReconPlot(Plot):
         #mlib.rcParams.update({'font.size': 16})
 
         fig = plt.figure(figsize=prop['figsize'])
-        if ax == None:
+        if ax is None:
             self.ax = plt.subplot()
         else:
             self.ax = ax
@@ -495,7 +495,7 @@ class ReconPlot(Plot):
         #--------------------------------------------------------------------------------------
            
         #Return axis if specified, otherwise display figure
-        if ax != None or return_ax == True:
+        if ax is not None or return_ax == True:
             return self.ax
         else:
             plt.show()

--- a/src/tropycal/tornado/dataset.py
+++ b/src/tropycal/tornado/dataset.py
@@ -342,7 +342,7 @@ class TornadoDataset():
         self.plot_obj = TornadoPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             cartopy_proj = self.plot_obj.proj
         

--- a/src/tropycal/tornado/plot.py
+++ b/src/tropycal/tornado/plot.py
@@ -104,19 +104,19 @@ class TornadoPlot(Plot):
         mnlon = (slon+elon)*.5
 
         #Add to coordinate extrema
-        if max_lat == None:
+        if max_lat is None:
             max_lat = max(mnlat)
         else:
             if max(mnlat) > max_lat: max_lat = max(mnlat)
-        if min_lat == None:
+        if min_lat is None:
             min_lat = min(mnlat)
         else:
             if min(mnlat) < min_lat: min_lat = min(mnlat)
-        if max_lon == None:
+        if max_lon is None:
             max_lon = max(mnlon)
         else:
             if max(mnlon) > max_lon: max_lon = max(mnlon)
-        if min_lon == None:
+        if min_lon is None:
             min_lon = min(mnlon)
         else:
             if min(mnlon) < min_lon: min_lon = min(mnlon)

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -181,7 +181,7 @@ class TrackDataset:
             raise RuntimeError("Accepted values for 'source' are 'hurdat' or 'ibtracs'")
             
         #Replace ibtracs with hurdat for atl/pac basins
-        if source == 'ibtracs' and ibtracs_hurdat == True:
+        if source == 'ibtracs' and ibtracs_hurdat:
             if self.basin in ['north_atlantic','east_pacific']:
                 self.__read_hurdat()
             elif self.basin == 'all':
@@ -250,7 +250,7 @@ class TrackDataset:
             raise RuntimeError("Only valid basins are 'north_atlantic', 'east_pacific' or 'both'")
         
         def read_hurdat(path,flag):
-            if flag == True:
+            if flag:
                 f = urllib.request.urlopen(path)
                 content = f.read()
                 content = content.decode("utf-8")
@@ -292,7 +292,7 @@ class TrackDataset:
                     add_basin = 'east_pacific'
                 elif line[0][0] == 'E':
                     add_basin = 'east_pacific'
-                if override_basin == True:
+                if override_basin:
                     add_basin = 'all'
                 
                 #add empty entry into dict
@@ -487,7 +487,7 @@ class TrackDataset:
             self.data[stormid]['ace'] = 0.0
 
             #Read in file
-            if use_ftp == True:
+            if use_ftp:
                 url = f"ftp://ftp.nhc.noaa.gov/atcf/btk/{file}"
             else:
                 url = f"https://ftp.nhc.noaa.gov/atcf/btk/{file}"
@@ -602,7 +602,7 @@ class TrackDataset:
         ibtracs_basin = basin_convert.get(self.basin,'')
         
         #read in ibtracs file
-        if ibtracs_online == True:
+        if ibtracs_online:
             path = self.ibtracs_url.replace("(basin)",ibtracs_basin)
             f = urllib.request.urlopen(path)
             content = f.read()
@@ -665,7 +665,7 @@ class TrackDataset:
                 self.data[use_id] = {'id':sid,'operational_id':'','name':name,'year':date.year,'season':int(year),'basin':self.basin}
                 self.data[use_id]['source'] = self.source
                 self.data[use_id]['source_info'] = 'Joint Typhoon Warning Center (unofficial)'
-                if self.neumann == True: self.data[use_id]['source_info'] += '& Charles Neumann reanalysis for South Hemisphere storms'
+                if self.neumann: self.data[use_id]['source_info'] += '& Charles Neumann reanalysis for South Hemisphere storms'
                 current_id = use_id
 
                 #add empty lists
@@ -675,7 +675,7 @@ class TrackDataset:
                 self.data[use_id]['ace'] = 0.0
 
             #Get neumann data for storms containing it
-            if self.neumann == True:
+            if self.neumann:
                 neumann_lat, neumann_lon, neumann_type, neumann_vmax, neumann_mslp = line[141:146]
                 if neumann_lat != "" and neumann_lon != "":
                     
@@ -744,7 +744,7 @@ class TrackDataset:
             
             
             #map JTWC to ibtracs ID (for neumann replacement)
-            if self.neumann == True:
+            if self.neumann:
                 if ibtracs_id not in map_id.keys():
                     map_id[ibtracs_id] = sid
             
@@ -789,7 +789,7 @@ class TrackDataset:
                 if wmo_type == "DS":
                     stype = "LO"
                 elif wmo_type == "TS":
-                    if np.isnan(jtwc_vmax) == True:
+                    if np.isnan(jtwc_vmax):
                         stype = 'LO'
                     elif jtwc_vmax < 34:
                         stype = 'TD'
@@ -798,7 +798,7 @@ class TrackDataset:
                     else:
                         stype = 'HU'
                 elif wmo_type == 'SS':
-                    if np.isnan(jtwc_vmax) == True:
+                    if np.isnan(jtwc_vmax):
                         stype = 'LO'
                     elif jtwc_vmax < 34:
                         stype = 'SD'
@@ -877,7 +877,7 @@ class TrackDataset:
                     elif stype == 'DS':
                         stype = 'LO'
                     else:
-                        if np.isnan(vmax) == True:
+                        if np.isnan(vmax):
                             stype = 'LO'
                         elif vmax < 34:
                             stype = 'TD'
@@ -931,7 +931,7 @@ class TrackDataset:
                 del(self.data[key])
         
         #Replace neumann entries
-        if self.neumann == True:
+        if self.neumann:
             
             #iterate through every neumann entry
             for key in neumann.keys():
@@ -949,9 +949,9 @@ class TrackDataset:
                 
         #Fix cyclone Catarina, if specified & requested
         all_keys = [k for k in self.data.keys()]
-        if '2004086S29318' in all_keys and self.catarina == True:
+        if '2004086S29318' in all_keys and self.catarina:
             self.data['2004086S29318'] = cyclone_catarina()
-        elif 'AL502004' in all_keys and self.catarina == True:
+        elif 'AL502004' in all_keys and self.catarina:
             self.data['AL502004'] = cyclone_catarina()
         
         #Determine time elapsed
@@ -1050,15 +1050,15 @@ class TrackDataset:
         """
         
         #Check if storm is str or tuple
-        if isinstance(storm, str) == True:
+        if isinstance(storm, str):
             key = storm
-        elif isinstance(storm, tuple) == True:
+        elif isinstance(storm, tuple):
             key = self.get_storm_id((storm[0],storm[1]))
         else:
             raise RuntimeError("Storm must be a string (e.g., 'AL052019') or tuple (e.g., ('Matthew',2016)).")
         
         #Retrieve key of given storm
-        if isinstance(key, str) == True:
+        if isinstance(key, str):
             
             #Check to see if tornado data exists for this storm
             if np.max(self.keys_tors) == 1:
@@ -1396,14 +1396,14 @@ class TrackDataset:
         if isinstance(year,int) == False and isinstance(year,list) == False:
             msg = "'year' must be of type int or list."
             raise TypeError(msg)
-        if isinstance(year,list) == True:
+        if isinstance(year,list):
             for i in year:
                 if isinstance(i,int) == False:
                     msg = "Elements of list 'year' must be of type int."
                     raise TypeError(msg)
         
         #Retrieve season object(s)
-        if isinstance(year,int) == True:
+        if isinstance(year,int):
             return self.__retrieve_season(year,basin)
         else:
             return_season = self.__retrieve_season(year[0],basin)
@@ -1556,7 +1556,7 @@ class TrackDataset:
         
         #Return if not plotting
         if plot == False:
-            if return_dict == True:
+            if return_dict:
                 return ace
             else:
                 return
@@ -1615,7 +1615,7 @@ class TrackDataset:
         #Plot comparison years
         if compare_years is not None:
             
-            if isinstance(compare_years, int) == True: compare_years = [compare_years]
+            if isinstance(compare_years, int): compare_years = [compare_years]
                 
             for year in compare_years:
                 
@@ -1826,7 +1826,7 @@ class TrackDataset:
         
         #Return if not plotting
         if plot == False:
-            if return_dict == True:
+            if return_dict:
                 return tc_days
             else:
                 return
@@ -1913,7 +1913,7 @@ class TrackDataset:
         #Plot comparison years
         if compare_years is not None and cat != 0:
             
-            if isinstance(compare_years, int) == True: compare_years = [compare_years]
+            if isinstance(compare_years, int): compare_years = [compare_years]
                 
             for year in compare_years:
                 
@@ -1969,7 +1969,7 @@ class TrackDataset:
                 transform=ax.transAxes,ha='right',va='top',zorder=10)
         
         #Show/save plot and close
-        if save_path is not None and isinstance(save_path,str) == True:
+        if save_path is not None and isinstance(save_path,str):
             plt.savefig(save_path,bbox_inches='tight')
         
         if return_dict:
@@ -2008,7 +2008,7 @@ class TrackDataset:
         if year_range is None:
             start_year = self.data[self.keys[0]]['year']
             end_year = self.data[self.keys[-1]]['year']
-        elif isinstance(year_range,(list,tuple)) == True:
+        elif isinstance(year_range,(list,tuple)):
             if len(year_range) != 2:
                 raise ValueError("year_range must be a tuple or list with 2 elements: (start_year, end_year)")
             start_year = int(year_range[0])
@@ -2030,7 +2030,7 @@ class TrackDataset:
         
         #Return if plot is not requested
         if plot == False:
-            if return_dict == True:
+            if return_dict:
                 return relationship
             else:
                 return
@@ -2046,9 +2046,9 @@ class TrackDataset:
         if storm is not None:
             
             #Check if storm is str or tuple
-            if isinstance(storm, str) == True:
+            if isinstance(storm, str):
                 pass
-            elif isinstance(storm, tuple) == True:
+            elif isinstance(storm, tuple):
                 storm = self.get_storm_id((storm[0],storm[1]))
             else:
                 raise RuntimeError("Storm must be a string (e.g., 'AL052019') or tuple (e.g., ('Matthew',2016)).")
@@ -2079,7 +2079,7 @@ class TrackDataset:
                 check = False
                 if it in ['SD','SS','TD','TS','HU'] and tr_label == True: check = True
                 if not it in ['SD','SS','TD','TS','HU'] and xt_label == True: check = True
-                if check == True:
+                if check:
                     plt.scatter(iv, ip, marker='o',s=80,color=get_color(it)[0],edgecolor='k',zorder=9)
                 else:
                     if it in ['SD','SS','TD','TS','HU'] and tr_label == False:
@@ -2125,7 +2125,7 @@ class TrackDataset:
         if save_path is not None and isinstance(save_path,str):
             plt.savefig(save_path,bbox_inches='tight')
         
-        if return_dict == True:
+        if return_dict:
             return {'ax':ax,'data':relationship}
         else:
             return ax
@@ -2197,7 +2197,7 @@ class TrackDataset:
         if year_range is None:
             start_year = self.data[self.keys[0]]['year']
             end_year = self.data[self.keys[-1]]['year']
-        elif isinstance(year_range,(list,tuple)) == True:
+        elif isinstance(year_range,(list,tuple)):
             if len(year_range) != 2:
                 raise ValueError("year_range must be a tuple or list with 2 elements: (start_year, end_year)")
             start_year = int(year_range[0])
@@ -2221,7 +2221,7 @@ class TrackDataset:
             
             #Filter for purely tropical/subtropical storm locations
             type_array = np.array(storm_data['type'])
-            if subtropical == True:
+            if subtropical:
                 idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))
             else:
                 idx = np.where((type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))
@@ -2237,7 +2237,7 @@ class TrackDataset:
             
             #Filter geographically
             if domain is not None:
-                if isinstance(domain,dict) == True:
+                if isinstance(domain,dict):
                     keys = domain.keys()
                     check = [False, False, False, False]
                     for key in keys:
@@ -2249,7 +2249,7 @@ class TrackDataset:
                         msg = "Custom domains must be of type dict with arguments for 'n', 's', 'e' and 'w'."
                         raise ValueError(msg)
                     idx = np.where((lat_tropical >= bound_s) & (lat_tropical <= bound_n) & (lon_tropical >= bound_w) & (lon_tropical <= bound_e))
-                elif isinstance(domain,str) == True:
+                elif isinstance(domain,str):
                     idx = np.where(basin_tropical==domain)
                 else:
                     msg = "domain must be of type str or dict."
@@ -2390,7 +2390,7 @@ class TrackDataset:
             start_year = self.data[self.keys[0]]['year']
             if start_year < 1950: start_year = 1950
             end_year = self.data[self.keys[-1]]['year']
-        elif isinstance(year_range,(list,tuple)) == True:
+        elif isinstance(year_range,(list,tuple)):
             if len(year_range) != 2:
                 raise ValueError("year_range must be a tuple or list with 2 elements: (start_year, end_year)")
             start_year = int(year_range[0])
@@ -2401,9 +2401,9 @@ class TrackDataset:
             raise TypeError("year_range must be of type tuple or list")
             
         #Check if storm is str or tuple
-        if isinstance(storm, str) == True:
+        if isinstance(storm, str):
             pass
-        elif isinstance(storm, tuple) == True:
+        elif isinstance(storm, tuple):
             storm = self.get_storm_id((storm[0],storm[1]))
         else:
             raise RuntimeError("Storm must be a string (e.g., 'AL052019') or tuple (e.g., ('Matthew',2016)).")
@@ -2843,7 +2843,7 @@ class TrackDataset:
                 import xarray as xr
                 
                 #Determine whether to use averages
-                if year_average == True:
+                if year_average:
                     years_listed = len(range(year_range[0],year_range[1]+1))
                     grid_z_years[0] = grid_z_years[0] / years_listed
                     years_listed = len(range(year_range_subtract[0],year_range_subtract[1]+1))
@@ -2877,7 +2877,7 @@ class TrackDataset:
                 raise RuntimeError("Error: xarray is not available. Install xarray in order to use the subtract year functionality.") from e
         else:
             #Determine whether to use averages
-            if year_average == True:
+            if year_average:
                 years_listed = len(range(year_range[0],year_range[1]+1))
                 grid_z = grid_z / years_listed
         

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -1074,7 +1074,7 @@ class TrackDataset:
             raise RuntimeError(error_message)
     
     
-    def plot_storm(self,storm,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+    def plot_storm(self,storm,domain="dynamic",plot_all_dots=False,ax=None,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single storm.
@@ -1089,8 +1089,6 @@ class TrackDataset:
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         save_path : str
@@ -1102,6 +1100,11 @@ class TrackDataset:
             Customization properties of storm track lines. Please refer to :ref:`options-prop` for available options.
         map_prop : dict
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         """
         
         #Retrieve requested storm
@@ -1125,13 +1128,13 @@ class TrackDataset:
             self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
-        plot_ax = self.plot_obj.plot_storm(storm_dict,domain,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_storm(storm_dict,domain,plot_all_dots,ax=ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax is not None or return_ax == True: return plot_ax
+        return plot_ax
     
     
-    def plot_storms(self,storms,domain="dynamic",title="TC Track Composite",plot_all_dots=False,labels=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+    def plot_storms(self,storms,domain="dynamic",title="TC Track Composite",plot_all_dots=False,labels=False,ax=None,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of multiple storms.
@@ -1150,8 +1153,6 @@ class TrackDataset:
             Whether to label storm titles on the plot. Default is False.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         save_path : str
@@ -1163,6 +1164,11 @@ class TrackDataset:
             Customization properties of storm track lines. Please refer to :ref:`options-prop` for available options.
         map_prop : dict
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         """
         
         #Create instance of plot object
@@ -1197,13 +1203,13 @@ class TrackDataset:
             self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
-        plot_ax = self.plot_obj.plot_storms(storm_dicts,domain,title,plot_all_dots,labels,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_storms(storm_dicts,domain,title,plot_all_dots,labels,ax=ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax is not None or return_ax == True: return plot_ax
+        return plot_ax
         
         
-    def plot_season(self,year,domain=None,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+    def plot_season(self,year,domain=None,ax=None,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single season.
@@ -1216,8 +1222,6 @@ class TrackDataset:
             Domain for the plot. Default is basin-wide. Please refer to :ref:`options-domain` for available domain options.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         save_path : str
@@ -1229,6 +1233,11 @@ class TrackDataset:
             Customization properties of storm track lines. Please refer to :ref:`options-prop` for available options.
         map_prop : dict
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         """
         
         #Retrieve season object
@@ -1249,10 +1258,10 @@ class TrackDataset:
             self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot season
-        plot_ax = self.plot_obj.plot_season(season,domain,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_season(season,domain,ax=ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax is not None or return_ax == True: return plot_ax
+        return plot_ax
     
     
     def search_name(self,name):
@@ -1402,7 +1411,7 @@ class TrackDataset:
                 return_season = return_season + self.__retrieve_season(i_year,basin)
             return return_season
     
-    def ace_climo(self,plot_year=None,compare_years=None,climo_year_range=None,date_range=None,rolling_sum=0,return_dict=False,plot=True,return_ax=False,save_path=None):
+    def ace_climo(self,plot_year=None,compare_years=None,climo_year_range=None,date_range=None,rolling_sum=0,return_dict=False,plot=True,save_path=None):
         
         r"""
         Creates and plots a climatology of accumulated cyclone energy (ACE).
@@ -1428,8 +1437,8 @@ class TrackDataset:
         
         Returns
         -------
-        None or dict
-            If return_dict is True, a dictionary containing data about the ACE climatology is returned.
+        axes or dict
+            By default, the plot axes is returned. If return_dict is True, a dictionary containing the axes and data about the ACE climatology is returned.
         """
         
         #Retrieve current year
@@ -1650,16 +1659,13 @@ class TrackDataset:
                 transform=ax.transAxes,ha='right',va='top',zorder=10)
         
         #Show/save plot and close
-        if save_path is None:
-            plt.show()
-        else:
+        if save_path is not None and isinstance(save_path,str):
             plt.savefig(save_path,bbox_inches='tight',facecolor='w')
-        plt.close()
         
-        if return_dict == True:
-            return ace
+        if return_dict:
+            return {'ax':ax,'ace':ace}
         else:
-            return
+            return ax
 
     def hurricane_days_climo(self,plot_year=None,compare_years=None,start_year=1950,rolling_sum=0,category=None,return_dict=False,plot=True,save_path=None):
         
@@ -1687,8 +1693,8 @@ class TrackDataset:
         
         Returns
         -------
-        None or dict
-            If return_dict is True, a dictionary containing data about the climatology is returned.
+        axes or dict
+            By default, the axes is returned. If return_dict is True, a dictionary containing the axes and data about the climatology is returned.
         """
         
         #Create empty dict
@@ -1963,16 +1969,13 @@ class TrackDataset:
                 transform=ax.transAxes,ha='right',va='top',zorder=10)
         
         #Show/save plot and close
-        if save_path is None:
-            plt.show()
-        else:
+        if save_path is not None and isinstance(save_path,str) == True:
             plt.savefig(save_path,bbox_inches='tight')
-        plt.close()
         
-        if return_dict == True:
-            return tc_days
+        if return_dict:
+            return {'ax':ax,'data':tc_days}
         else:
-            return
+            return ax
     
     def wind_pres_relationship(self,storm=None,year_range=None,return_dict=False,plot=True,save_path=None):
         
@@ -1994,8 +1997,8 @@ class TrackDataset:
         
         Returns
         -------
-        dict
-            If return_dict is True, a dictionary containing data about the wind vs. MSLP relationship climatology is returned.
+        ax or dict
+            By default, the plot axes is returned. If return_dict is True, a dictionary containing data about the wind vs. MSLP relationship climatology is returned.
         """
         
         #Define empty dictionary
@@ -2033,7 +2036,7 @@ class TrackDataset:
                 return
         
         #Create figure
-        fig = plt.figure(figsize=(12,9.5),dpi = 200)
+        fig,ax = plt.subplots(figsize=(12,9.5),dpi = 200)
 
         #Plot climatology
         CS = plt.pcolor(xedges,yedges,counts**0.3,vmin=0,vmax=np.amax(counts)**.3,cmap='gnuplot2_r')
@@ -2119,16 +2122,13 @@ class TrackDataset:
                 transform=plt.gca().transAxes,ha='right',va='bottom',zorder=10)        
         
         #Show/save plot and close
-        if save_path is None:
-            plt.show()
-        else:
+        if save_path is not None and isinstance(save_path,str):
             plt.savefig(save_path,bbox_inches='tight')
-        plt.close()
         
         if return_dict == True:
-            return relationship
+            return {'ax':ax,'data':relationship}
         else:
-            return
+            return ax
     
     def rank_storm(self,metric,return_df=True,ascending=False,domain=None,year_range=None,date_range=None,subtropical=True):
         
@@ -2610,7 +2610,7 @@ class TrackDataset:
             return p
 
     def gridded_stats(self,request,thresh={},storm=None,year_range=None,year_range_subtract=None,year_average=False,
-                      date_range=('1/1','12/31'),binsize=1,domain=None,ax=None,return_ax=False,
+                      date_range=('1/1','12/31'),binsize=1,domain=None,ax=None,
                       return_array=False,cartopy_proj=None,prop={},map_prop={}):
         
         r"""
@@ -2670,8 +2670,6 @@ class TrackDataset:
             Domain for the plot. Default is "dynamic". Please refer to :ref:`options-domain` for available domain options.
         ax : axes, optional
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool, optional
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         return_array : bool, optional
             If True, returns the gridded 2D array used to generate the plot. Default is False.
         cartopy_proj : ccrs, optional
@@ -2686,7 +2684,7 @@ class TrackDataset:
         
         Returns
         -------
-        By default, nothing is returned and a plot is displayed. If either "return_ax" or "return_array" are set to True, those respective data are returned. If both are set to true, a dictionary is returned containing both.
+        By default, the plot axes is returned. If "return_array" are set to True, a dictionary is returned containing both the axes and data array.
         """
 
         default_prop = {'smooth':None}
@@ -2973,10 +2971,10 @@ class TrackDataset:
             grid_z = grid_z_zeros.copy()
         
         #Plot gridded field
-        plot_ax = self.plot_obj.plot_gridded(grid_x,grid_y,grid_z,varname,VEC_FLAG,domain,ax=ax,return_ax=True,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_gridded(grid_x,grid_y,grid_z,varname,VEC_FLAG,domain,ax=ax,prop=prop,map_prop=map_prop)
         
         #Format grid into xarray if specified
-        if return_array == True:
+        if return_array:
             try:
                 #Import xarray and construct DataArray, replacing NaNs with zeros
                 import xarray as xr
@@ -2986,12 +2984,10 @@ class TrackDataset:
                 raise RuntimeError("Error: xarray is not available. Install xarray in order to use the 'return_array' flag.") from e
 
         #Return axis
-        if return_ax == True and return_array == True:
+        if return_array:
             return {'ax':plot_ax,'array':arr}
-        if return_ax == False and return_array == True:
-            return arr
-        if ax is not None or return_ax == True: return plot_ax
-        
+        else:
+            return plot_ax
 
     
     def assign_storm_tornadoes(self,dist_thresh=1000,tornado_path='spc'):
@@ -3040,7 +3036,7 @@ class TrackDataset:
         #Update user on status
         print(f'--> Completed assigning tornadoes to storm (%.2f seconds)' % (dt.now()-timer_start).total_seconds())
         
-    def plot_TCtors_rotated(self,storms,mag_thresh=0,return_ax=False,return_df=False,save_path=None):
+    def plot_TCtors_rotated(self,storms,mag_thresh=0,return_df=False,save_path=None):
         
         r"""
         Plot tracks of tornadoes relative to the storm motion vector of the tropical cyclone.
@@ -3051,8 +3047,6 @@ class TrackDataset:
             Storm(s) for which to plot motion-relative tornado data for. Can be either a list of storm IDs/tuples for which to create a composite of, or a string "all" for all storms containing tornado data.
         mag_thresh : int
             Minimum threshold for tornado rating.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         return_df : bool
             Whether to return the pandas DataFrame containing the composite tornado data. Default is False.
         save_path : str
@@ -3060,8 +3054,8 @@ class TrackDataset:
         
         Returns
         -------
-        None or dict
-            If either "return_ax" or "return_df" are set to True, returns a dict containing their respective data.
+        ax or dict
+            By default, the plot axes is returned. If "return_df" is set to True, returns a dict containing both the data and the axes plot
         
         Notes
         -----
@@ -3153,19 +3147,12 @@ class TrackDataset:
         ax.text(0.99,0.01,plot_credit(),fontsize=8,color='k',alpha=0.7,
                 transform=ax.transAxes,ha='right',va='bottom',zorder=10)
         
-        #Return axis or show figure
-        return_dict = {}
-        if return_ax == True:
-            return_dict['ax'] = ax
+        #Save image if specified
+        if save_path is not None and isinstance(save_path,str):
+            plt.savefig(save_path,bbox_inches='tight')
+        
+        #Return data
+        if return_df:
+            return {'ax':ax,'df':stormTors}
         else:
-            #Save image if specified
-            if save_path is not None and isinstance(save_path,str) == True:
-                plt.savefig(save_path,bbox_inches='tight')
-            else:
-                plt.show()
-            plt.close()
-
-        if return_df == True:
-            return_dict['df'] = stormTors
-        if len(return_dict) > 0:
-            return return_dict
+            return ax

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -1117,7 +1117,7 @@ class TrackDataset:
             self.plot_obj = TrackPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             if max(storm_dict['lon']) > 150 or min(storm_dict['lon']) < -150:
                 self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
             else:
@@ -1129,7 +1129,7 @@ class TrackDataset:
         plot_ax = self.plot_obj.plot_storm(storm_dict,domain,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax != None or return_ax == True: return plot_ax
+        if ax is not None or return_ax == True: return plot_ax
     
     
     def plot_storms(self,storms,domain="dynamic",title="TC Track Composite",plot_all_dots=False,labels=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
@@ -1190,7 +1190,7 @@ class TrackDataset:
             if min(storm_dict['lon']) < min_lon: min_lon = min(storm_dict['lon'])
             
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             if max(storm_dict['lon']) > 150 or min(storm_dict['lon']) < -150:
                 self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
             else:
@@ -1202,7 +1202,7 @@ class TrackDataset:
         plot_ax = self.plot_obj.plot_storms(storm_dicts,domain,title,plot_all_dots,labels,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax != None or return_ax == True: return plot_ax
+        if ax is not None or return_ax == True: return plot_ax
         
         
     def plot_season(self,year,domain=None,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
@@ -1243,7 +1243,7 @@ class TrackDataset:
             self.plot_obj = TrackPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             if season.basin in ['east_pacific','west_pacific','south_pacific','australia','all']:
                 self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
             else:
@@ -1255,7 +1255,7 @@ class TrackDataset:
         plot_ax = self.plot_obj.plot_season(season,domain,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax != None or return_ax == True: return plot_ax
+        if ax is not None or return_ax == True: return plot_ax
     
     
     def search_name(self,name):
@@ -1571,7 +1571,7 @@ class TrackDataset:
         ax.set_xlim(julian_start[4],julian[-1])
 
         #Add plot title
-        if plot_year == None:
+        if plot_year is None:
             title_string = f"{self.basin.title().replace('_',' ')} Accumulated Cyclone Energy Climatology"
         else:
             cur_year = (dt.now()).year
@@ -1587,7 +1587,7 @@ class TrackDataset:
         ax.set_title(f"{title_string}{title_add}",fontsize=12,fontweight='bold',loc='left')
         
         #Plot requested year
-        if plot_year != None:
+        if plot_year is not None:
             
             year_julian = np.copy(julian)
             year_ace = ace[str(plot_year)]['ace']
@@ -1607,7 +1607,7 @@ class TrackDataset:
             ax.plot(year_julian[year_genesis],year_ace[year_genesis],'D',color='k',ms=5,mec='w',mew=0.5,zorder=7,label='TC Genesis')
             
         #Plot comparison years
-        if compare_years != None:
+        if compare_years is not None:
             
             if isinstance(compare_years, int) == True: compare_years = [compare_years]
                 
@@ -1653,7 +1653,7 @@ class TrackDataset:
                 transform=ax.transAxes,ha='right',va='top',zorder=10)
         
         #Show/save plot and close
-        if save_path == None:
+        if save_path is None:
             plt.show()
         else:
             plt.savefig(save_path,bbox_inches='tight',facecolor='w')
@@ -1801,7 +1801,7 @@ class TrackDataset:
         
         #Determine type of plot to make
         category_match = {0:'ts',1:'c1',2:'c2',3:'c3',4:'c4',5:'c5'}
-        if category == None:
+        if category is None:
             cat = 0
         else:
             cat = category_match.get(category,'c1')
@@ -1851,7 +1851,7 @@ class TrackDataset:
             add_str = category_names.get(cat)
         
         #Add plot title
-        if plot_year == None:
+        if plot_year is None:
             title_string = f"{self.basin.title().replace('_',' ')} Accumulated {add_str} Days"
         else:
             cur_year = (dt.now()).year
@@ -1867,7 +1867,7 @@ class TrackDataset:
         ax.set_title(f"{title_string}{title_add}",fontsize=12,fontweight='bold',loc='left')
         
         #Plot requested year
-        if plot_year != None:
+        if plot_year is not None:
             
             if cat == 0:
                 year_labels = []
@@ -1908,7 +1908,7 @@ class TrackDataset:
                 ax.plot(year_julian[year_genesis],year_tc_days[year_genesis],'D',color='#FF7CFF',ms=5,mec='#750775',mew=0.5,zorder=7,label='TC Genesis')
             
         #Plot comparison years
-        if compare_years != None and cat != 0:
+        if compare_years is not None and cat != 0:
             
             if isinstance(compare_years, int) == True: compare_years = [compare_years]
                 
@@ -1937,7 +1937,7 @@ class TrackDataset:
         
         #Plot all climatological values
         if cat == 0:
-            if plot_year == None:
+            if plot_year is None:
                 add_str = ["" for i in all_thres]
             else:
                 add_str = [f" | {plot_year}: {i}" for i in year_labels[::-1]]
@@ -1966,7 +1966,7 @@ class TrackDataset:
                 transform=ax.transAxes,ha='right',va='top',zorder=10)
         
         #Show/save plot and close
-        if save_path == None:
+        if save_path is None:
             plt.show()
         else:
             plt.savefig(save_path,bbox_inches='tight')
@@ -2005,7 +2005,7 @@ class TrackDataset:
         relationship = {}
         
         #Determine year range of dataset
-        if year_range == None:
+        if year_range is None:
             start_year = self.data[self.keys[0]]['year']
             end_year = self.data[self.keys[-1]]['year']
         elif isinstance(year_range,(list,tuple)) == True:
@@ -2043,7 +2043,7 @@ class TrackDataset:
         plt.plot(xedges,[testfit(vp,x,2) for x in xedges],'k--',linewidth=2)
         
         #Plot storm, if specified
-        if storm != None:
+        if storm is not None:
             
             #Check if storm is str or tuple
             if isinstance(storm, str) == True:
@@ -2122,7 +2122,7 @@ class TrackDataset:
                 transform=plt.gca().transAxes,ha='right',va='bottom',zorder=10)        
         
         #Show/save plot and close
-        if save_path == None:
+        if save_path is None:
             plt.show()
         else:
             plt.savefig(save_path,bbox_inches='tight')
@@ -2197,7 +2197,7 @@ class TrackDataset:
             raise ValueError("Metric requested for sorting is not available. Please reference the documentation for acceptable entries for 'metric'.")
         
         #Determine year range of dataset
-        if year_range == None:
+        if year_range is None:
             start_year = self.data[self.keys[0]]['year']
             end_year = self.data[self.keys[-1]]['year']
         elif isinstance(year_range,(list,tuple)) == True:
@@ -2239,7 +2239,7 @@ class TrackDataset:
             basin_tropical = np.array(storm_data['wmo_basin'])[idx]
             
             #Filter geographically
-            if domain != None:
+            if domain is not None:
                 if isinstance(domain,dict) == True:
                     keys = domain.keys()
                     check = [False, False, False, False]
@@ -2271,7 +2271,7 @@ class TrackDataset:
                     basin_tropical = basin_tropical[idx]
             
             #Filter by time
-            if date_range != None:
+            if date_range is not None:
                 start_time = dt.strptime(f"{storm_data['year']}/{date_range[0]}",'%Y/%m/%d')
                 end_time = dt.strptime(f"{storm_data['year']}/{date_range[1]}",'%Y/%m/%d')
                 idx = np.array([i for i in range(len(lat_tropical)) if date_tropical[i] >= start_time and date_tropical[i] <= end_time])
@@ -2389,7 +2389,7 @@ class TrackDataset:
             warnings.warn(warning_str)
 
         #Determine year range of dataset
-        if year_range == None:
+        if year_range is None:
             start_year = self.data[self.keys[0]]['year']
             if start_year < 1950: start_year = 1950
             end_year = self.data[self.keys[-1]]['year']
@@ -2479,7 +2479,7 @@ class TrackDataset:
         thresh = default_thresh
 
         #Determine domain over which to filter data
-        if domain == None:
+        if domain is None:
             lon_min = 0
             lon_max = 360
             lat_min = -90
@@ -2742,7 +2742,7 @@ class TrackDataset:
         #---------------------------------------------------------------------------------------------------
         
         #Perform analysis either once or twice depending on year_range_subtract
-        if year_range_subtract == None:
+        if year_range_subtract is None:
             years_analysis = [year_range]
         else:
             years_analysis = [year_range,year_range_subtract]
@@ -2893,9 +2893,9 @@ class TrackDataset:
             self.plot_obj = TrackPlot()
         
         #Create cartopy projection using basin
-        if domain == None:
+        if domain is None:
             domain = self.basin
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             if max(points['lon']) > 150 or min(points['lon']) < -150:
                 self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
             else:
@@ -2932,7 +2932,7 @@ class TrackDataset:
             else:
                 y_r_title = f'{year_range[0]} {endash} {year_range[1]}'
             add_avg = ' year-avg' if year_average == True else ''
-            if year_range_subtract == None:
+            if year_range_subtract is None:
                 title_R = f'{date_range[0].replace("/"," ")} {endash} {date_range[1].replace("/"," ")} {dot} {y_r_title}{add_avg}'
             else:
                 if np.subtract(*year_range_subtract)==0:
@@ -2993,7 +2993,7 @@ class TrackDataset:
             return {'ax':plot_ax,'array':arr}
         if return_ax == False and return_array == True:
             return arr
-        if ax != None or return_ax == True: return plot_ax
+        if ax is not None or return_ax == True: return plot_ax
         
 
     
@@ -3162,7 +3162,7 @@ class TrackDataset:
             return_dict['ax'] = ax
         else:
             #Save image if specified
-            if save_path != None and isinstance(save_path,str) == True:
+            if save_path is not None and isinstance(save_path,str) == True:
                 plt.savefig(save_path,bbox_inches='tight')
             else:
                 plt.show()

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -1117,13 +1117,12 @@ class TrackDataset:
             self.plot_obj = TrackPlot()
         
         #Create cartopy projection
-        if cartopy_proj is None:
-            if max(storm_dict['lon']) > 150 or min(storm_dict['lon']) < -150:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
-            else:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
-        else:
+        if cartopy_proj is not None:
             self.plot_obj.proj = cartopy_proj
+        elif max(storm_dict['lon']) > 150 or min(storm_dict['lon']) < -150:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
+        else:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
         plot_ax = self.plot_obj.plot_storm(storm_dict,domain,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
@@ -1190,13 +1189,12 @@ class TrackDataset:
             if min(storm_dict['lon']) < min_lon: min_lon = min(storm_dict['lon'])
             
         #Create cartopy projection
-        if cartopy_proj is None:
-            if max(storm_dict['lon']) > 150 or min(storm_dict['lon']) < -150:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
-            else:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
-        else:
+        if cartopy_proj is not None:
             self.plot_obj.proj = cartopy_proj
+        elif max(storm_dict['lon']) > 150 or min(storm_dict['lon']) < -150:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
+        else:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
         plot_ax = self.plot_obj.plot_storms(storm_dicts,domain,title,plot_all_dots,labels,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
@@ -1243,13 +1241,12 @@ class TrackDataset:
             self.plot_obj = TrackPlot()
         
         #Create cartopy projection
-        if cartopy_proj is None:
-            if season.basin in ['east_pacific','west_pacific','south_pacific','australia','all']:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
-            else:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
-        else:
+        if cartopy_proj is not None:
             self.plot_obj.proj = cartopy_proj
+        elif season.basin in ['east_pacific','west_pacific','south_pacific','australia','all']:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
+        else:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot season
         plot_ax = self.plot_obj.plot_season(season,domain,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -81,6 +81,25 @@ class TrackDataset:
     -------
     Dataset
         An instance of Dataset.
+    
+    Notes
+    -----
+    This object contains information about all storms in a basin, as well as methods to analyze the dataset and to retrieve individual storms from the dataset.
+    
+    The following block of code creates an instance of a TrackDataset() object and stores it in a variable called "basin":
+    
+    .. code-block:: python
+    
+        from tropycal import tracks
+        basin = tracks.TrackDataset()
+        
+    With an instance of TrackDataset created, any of the methods listed below can be accessed via the "basin" variable:
+    
+    .. code-block:: python
+    
+        storm = basin.get_storm(("katrina",2005))
+    
+    For IBTrACS datasets, please refer to :ref:`ibtracs-caveats` for pros and cons of each mode of IBTrACS data available.
     """
  
     def __repr__(self):
@@ -109,6 +128,7 @@ class TrackDataset:
                         'Maximum wind':f"{max_wind} knots ({max_wind_name})",
                         'Minimum pressure':f"{min_mslp} hPa ({min_mslp_name})",
                         'Year range':f"{self.data[self.keys[0]]['year']} {emdash} {self.data[self.keys[-1]]['year']}"}
+        
         #Add dataset summary
         summary.append("Dataset Summary:")
         add_space = np.max([len(key) for key in summary_keys.keys()])+3
@@ -995,7 +1015,7 @@ class TrackDataset:
         Parameters
         ----------
         storm : string
-            String containing the storm (e.g., "AL052019").
+            String containing the storm ID (e.g., "AL052019").
             
         Returns
         -------
@@ -1054,7 +1074,7 @@ class TrackDataset:
             raise RuntimeError(error_message)
     
     
-    def plot_storm(self,storm,domain="dynamic",plot_all=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+    def plot_storm(self,storm,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single storm.
@@ -1064,8 +1084,8 @@ class TrackDataset:
         storm : str, tuple or dict
             Requested storm. Can be either string of storm ID (e.g., "AL052019"), tuple with storm name and year (e.g., ("Matthew",2016)), or a dict entry.
         domain : str
-            Domain for the plot. Default is "dynamic". Please refer to :ref:`options-domain` for available domain options.
-        plot_all : bool
+            Domain for the plot. Default is "dynamic". "dynamic_tropical" is also available. Please refer to :ref:`options-domain` for available domain options.
+        plot_all_dots : bool
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
@@ -1106,13 +1126,13 @@ class TrackDataset:
             self.plot_obj.proj = cartopy_proj
             
         #Plot storm
-        plot_ax = self.plot_obj.plot_storm(storm_dict,domain,plot_all,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_storm(storm_dict,domain,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
         if ax != None or return_ax == True: return plot_ax
     
     
-    def plot_storms(self,storms,domain="dynamic",title_text="TC Track Composite",filter_dates=('1/1','12/31'),plot_all_dots=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+    def plot_storms(self,storms,domain="dynamic",title="TC Track Composite",plot_all_dots=False,labels=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of multiple storms.
@@ -1123,8 +1143,12 @@ class TrackDataset:
             List of requested storms. List can contain either strings of storm ID (e.g., "AL052019"), tuples with storm name and year (e.g., ("Matthew",2016)), or dict entries.
         domain : str
             Domain for the plot. Default is "dynamic". Please refer to :ref:`options-domain` for available domain options.
+        title : str
+            Title string to display on the plot. Default is "TC Track Composite".
         plot_all_dots : bool
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
+        labels : bool
+            Whether to label storm titles on the plot. Default is False.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
         return_ax : bool
@@ -1175,13 +1199,13 @@ class TrackDataset:
             self.plot_obj.proj = cartopy_proj
             
         #Plot storm
-        plot_ax = self.plot_obj.plot_storms(storm_dicts,domain,title_text,filter_dates,plot_all_dots,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_storms(storm_dicts,domain,title,plot_all_dots,labels,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
         if ax != None or return_ax == True: return plot_ax
         
         
-    def plot_season(self,year,domain=None,ax=None,return_ax=False,cartopy_proj=None,prop={},map_prop={}):
+    def plot_season(self,year,domain=None,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single season.
@@ -1190,12 +1214,16 @@ class TrackDataset:
         ----------
         year : int
             Year to retrieve season data. If in southern hemisphere, year is the 2nd year of the season (e.g., 1975 for 1974-1975).
+        domain : str
+            Domain for the plot. Default is basin-wide. Please refer to :ref:`options-domain` for available domain options.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
         return_ax : bool
             If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
+        save_path : str
+            Relative or full path of directory to save the image in. If none, image will not be saved.
         
         Other Parameters
         ----------------
@@ -1224,7 +1252,7 @@ class TrackDataset:
             self.plot_obj.proj = cartopy_proj
             
         #Plot season
-        plot_ax = self.plot_obj.plot_season(season,domain,ax=ax,return_ax=return_ax,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_season(season,domain,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
         if ax != None or return_ax == True: return plot_ax
@@ -1380,16 +1408,18 @@ class TrackDataset:
     def ace_climo(self,plot_year=None,compare_years=None,climo_year_range=None,date_range=None,rolling_sum=0,return_dict=False,plot=True,return_ax=False,save_path=None):
         
         r"""
-        Creates a climatology of accumulated cyclone energy (ACE).
+        Creates and plots a climatology of accumulated cyclone energy (ACE).
         
         Parameters
         ----------
         plot_year : int
-            Year to highlight. If current year, plot will be drawn through today.
+            Year to highlight. If current year, plot will be drawn through today. If none, no year will be highlighted.
         compare_years : int or list
             Seasons to compare against. Can be either a single season (int), or a range or list of seasons (list).
-        start_year : int
-            Year to begin calculating the climatology over. Default is 1950.
+        climo_year_range : tuple
+            Start and end years to compute the climatology over. Default is from 1950 to last year.
+        date_range : tuple
+            Start and end dates to plot, both strings formatted as "month/day". Default is entire calendar year.
         rolling_sum : int
             Days to calculate a rolling sum over. Default is 0 (annual running sum).
         return_dict : bool
@@ -1405,14 +1435,11 @@ class TrackDataset:
             If return_dict is True, a dictionary containing data about the ACE climatology is returned.
         """
         
+        #Retrieve current year
         cur_year = dt.now().year
         
         if climo_year_range is None:
             climo_year_range = (1950,dt.now().year-1)
-        #if plot_year!=None and plot_year<start_year:
-        #    raise ValueError("One of the years is before the climatology start_year.")            
-        #if compare_years!=None and np.any(np.asarray(compare_years)<start_year):
-        #    raise ValueError("One of the years is before the climatology start_year.")
         
         if self.source == 'ibtracs':
             warnings.warn("This function is not currently configured to work for the ibtracs dataset.")
@@ -1543,22 +1570,13 @@ class TrackDataset:
         #Limit plot from May onward
         ax.set_xlim(julian_start[4],julian[-1])
 
-        
-        if date_range is None:
-            if plot_year == cur_year:
-                tmax = dt.now().strftime('%m/%d')
-            else:
-                tmax = '12/31'
-            date_range = ('1/1',tmax)
-        date_range = [dt.strptime(t,'%m/%d') for t in date_range]
-            
         #Add plot title
         if plot_year == None:
             title_string = f"{self.basin.title().replace('_',' ')} Accumulated Cyclone Energy Climatology"
         else:
             cur_year = (dt.now()).year
             if plot_year == cur_year:
-                add_current = f"(through {date_range[-1]:%b %d})"
+                add_current = f"(through {dt.now().strftime('%m/%d')})"
             else:
                 add_current = ""
             title_string = f"{plot_year} {self.basin.title().replace('_',' ')} Accumulated Cyclone Energy {add_current}"
@@ -1582,16 +1600,7 @@ class TrackDataset:
                 year_julian = year_julian[:cur_julian+1]
                 year_ace = year_ace[:cur_julian+1]
                 year_genesis = year_genesis[:cur_julian+1]
-        
-            END_julian = int(convert_to_julian( date_range[-1].replace(year=2019,minute=0,second=0) ))*4 - int(rolling_sum*4)
-            year_julian = year_julian[:END_julian+1]
-            year_ace = year_ace[:END_julian+1]
-            year_genesis = year_genesis[:END_julian+1]
-            #ax.plot(year_julian[-1],year_ace[-1],'o',color='#FF7CFF',ms=8,mec='#750775',mew=0.8,zorder=8)
-            #ax.plot(year_julian,year_ace,'-',color='#750775',linewidth=2.8,zorder=6)
-            #ax.plot(year_julian,year_ace,'-',color='#FF7CFF',linewidth=2.0,zorder=6,label=f'{plot_year} ACE ({np.max(year_ace):.1f})')
-            #ax.plot(year_julian[year_genesis],year_ace[year_genesis],'D',color='#FF7CFF',ms=5,mec='#750775',mew=0.5,zorder=7,label='TC Genesis')
-            
+
             ax.plot(year_julian[-1],year_ace[-1],'o',color='k',ms=8,mec='w',mew=0.8,zorder=8)
             ax.plot(year_julian,year_ace,'-',color='w',linewidth=2.8,zorder=6)
             ax.plot(year_julian,year_ace,'-',color='k',linewidth=2.0,zorder=6,label=f'{plot_year} ACE ({np.max(year_ace):.1f})')
@@ -1670,17 +1679,19 @@ class TrackDataset:
             Year to begin calculating the climatology over. Default is 1950.
         rolling_sum : int
             Days to calculate a rolling sum over. Default is 0 (annual running sum).
+        category : int
+            SSHWS Category to generate the data and plot for. Use 0 for tropical storm. If none (default), a plot will be generated for all categories.
         return_dict : bool
             Determines whether to return data from this function. Default is False.
         plot : bool
-            Determines whether to generate a plot or not. If False, function simply returns ace dictionary.
+            Determines whether to generate a plot or not. If False, function simply returns data dictionary.
         save_path : str
             Determines the file path to save the image to. If blank or none, image will be directly shown.
         
         Returns
         -------
         None or dict
-            If return_dict is True, a dictionary containing data about the ACE climatology is returned.
+            If return_dict is True, a dictionary containing data about the climatology is returned.
         """
         
         #Create empty dict
@@ -2147,7 +2158,7 @@ class TrackDataset:
         ascending : bool
             Whether to return rank in ascending order (True) or descending order (False). Default is False.
         domain : str
-            String representing either a bounded region 'latW/latE/latS/latN', or a basin name. Default is entire basin.
+            Geographic domain. Default is entire basin. Please refer to :ref:`options-domain` for available domain options.
         year_range : list or tuple
             List or tuple representing the start and end years (e.g., (1950,2018)). Default is start and end years of dataset.
         date_range : list or tuple
@@ -2229,13 +2240,23 @@ class TrackDataset:
             
             #Filter geographically
             if domain != None:
-                if isinstance(domain,str) == False:
-                    raise TypeError("domain must be of type str.")
-                if '/' in domain:
-                    bound_w,bound_e,bound_s,bound_n = [float(i) for i in domain.split("/")]
+                if isinstance(domain,dict) == True:
+                    keys = domain.keys()
+                    check = [False, False, False, False]
+                    for key in keys:
+                        if key[0].lower() == 'n': check[0] = True; bound_n = domain[key]
+                        if key[0].lower() == 's': check[1] = True; bound_s = domain[key]
+                        if key[0].lower() == 'e': check[2] = True; bound_e = domain[key]
+                        if key[0].lower() == 'w': check[3] = True; bound_w = domain[key]
+                    if False in check:
+                        msg = "Custom domains must be of type dict with arguments for 'n', 's', 'e' and 'w'."
+                        raise ValueError(msg)
                     idx = np.where((lat_tropical >= bound_s) & (lat_tropical <= bound_n) & (lon_tropical >= bound_w) & (lon_tropical <= bound_e))
-                else:
+                elif isinstance(domain,str) == True:
                     idx = np.where(basin_tropical==domain)
+                else:
+                    msg = "domain must be of type str or dict."
+                    raise TypeError(msg)
                 if len(idx[0]) == 0: continue
                 
                 #Check for subset type
@@ -2439,7 +2460,7 @@ class TrackDataset:
             
             Units of all wind variables = kt, and pressure variables = hPa. These are added to the subtitle.
         domain : str
-            String or tuple representing a bounded region, 'latW/latE/latS/latN'.
+            Geographic domain. Default is entire basin. Please refer to :ref:`options-domain` for available domain options.
         doInterp : bool
             Whether to interpolate track data to hourly. Default is False.
         return_keys : bool
@@ -2452,25 +2473,31 @@ class TrackDataset:
         """
         
         #Update thresh based on input
-        default_thresh={'sample_min':1,'p_max':9999,'p_min':0,'v_min':0,'v_max':9999,'dv_min':-9999,'dp_max':9999,'dv_max':9999,'dp_min':-9999,'speed_max':9999,'speed_min':-9999,
-                        'dt_window':24,'dt_align':'middle'}
+        default_thresh={'sample_min':1,'p_max':9999,'p_min':0,'v_min':0,'v_max':9999,'dv_min':-9999,'dp_max':9999,'dv_max':9999,'dp_min':-9999,'speed_max':9999,'speed_min':-9999,'dt_window':24,'dt_align':'middle'}
         for key in thresh:
             default_thresh[key] = thresh[key]
         thresh = default_thresh
 
         #Determine domain over which to filter data
-        
-        if domain is None:
-            domain = (0,360,-90,90)
+        if domain == None:
+            lon_min = 0
+            lon_max = 360
+            lat_min = -90
+            lat_max = 90
         else:
-            domain = (domain['w'],domain['e'],domain['s'],domain['n'])
-        lon_min,lon_max,lat_min,lat_max = domain
-        
-        #if isinstance(domain,str):
-        #    lon_min,lon_max,lat_min,lat_max = [float(i) for i in domain.split("/")]
-        #else:
-        #    lon_min,lon_max,lat_min,lat_max = domain
-        
+            keys = domain.keys()
+            check = [False, False, False, False]
+            for key in keys:
+                if key[0].lower() == 'n': check[0] = True; lat_max = domain[key]
+                if key[0].lower() == 's': check[1] = True; lat_min = domain[key]
+                if key[0].lower() == 'e': check[2] = True; lon_max = domain[key]
+                if key[0].lower() == 'w': check[3] = True; lon_min = domain[key]
+            if False in check:
+                msg = "Custom domains must be of type dict with arguments for 'n', 's', 'e' and 'w'."
+                raise ValueError(msg)
+            if lon_max < 0: lon_max += 360.0
+            if lon_min < 0: lon_min += 360.0
+
         #Determine year and date range
         year_min,year_max = year_range
         date_min,date_max = [dt.strptime(i,'%m/%d') for i in date_range]
@@ -2586,7 +2613,7 @@ class TrackDataset:
             return p
 
     def gridded_stats(self,request,thresh={},storm=None,year_range=None,year_range_subtract=None,year_average=False,
-                      date_range=('1/1','12/31'),binsize=1,domain=None,ax=None,return_ax=False,\
+                      date_range=('1/1','12/31'),binsize=1,domain=None,ax=None,return_ax=False,
                       return_array=False,cartopy_proj=None,prop={},map_prop={}):
         
         r"""
@@ -2659,6 +2686,10 @@ class TrackDataset:
             Customization properties of plot. Please refer to :ref:`options-prop-gridded` for available options.
         map_prop : dict, optional
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        
+        Returns
+        -------
+        By default, nothing is returned and a plot is displayed. If either "return_ax" or "return_array" are set to True, those respective data are returned. If both are set to true, a dictionary is returned containing both.
         """
 
         default_prop = {'smooth':None}
@@ -3012,7 +3043,7 @@ class TrackDataset:
         #Update user on status
         print(f'--> Completed assigning tornadoes to storm (%.2f seconds)' % (dt.now()-timer_start).total_seconds())
         
-    def plot_TCtors_rotated(self,storms,mag_thresh=0,return_ax=False,return_df=False):
+    def plot_TCtors_rotated(self,storms,mag_thresh=0,return_ax=False,return_df=False,save_path=None):
         
         r"""
         Plot tracks of tornadoes relative to the storm motion vector of the tropical cyclone.
@@ -3027,6 +3058,8 @@ class TrackDataset:
             If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         return_df : bool
             Whether to return the pandas DataFrame containing the composite tornado data. Default is False.
+        save_path : str
+            Relative or full path of directory to save the image in. If none, image will not be saved.
         
         Returns
         -------
@@ -3128,7 +3161,11 @@ class TrackDataset:
         if return_ax == True:
             return_dict['ax'] = ax
         else:
-            plt.show()
+            #Save image if specified
+            if save_path != None and isinstance(save_path,str) == True:
+                plt.savefig(save_path,bbox_inches='tight')
+            else:
+                plt.show()
             plt.close()
 
         if return_df == True:

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -39,7 +39,7 @@ class TrackPlot(Plot):
         
         self.use_credit = True
     
-    def plot_storm(self,storm,domain="dynamic",plot_all=False,ax=None,return_ax=False,track_labels=False,save_path=None,prop={},map_prop={}):
+    def plot_storm(self,storm,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,track_labels=False,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single storm track.
@@ -54,7 +54,7 @@ class TrackPlot(Plot):
             "north_atlantic" - North Atlantic Ocean basin
             "pacific" - East/Central Pacific Ocean basin
             "lonW/lonE/latS/latN" - Custom plot domain
-        plot_all : bool
+        plot_all_dots : bool
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
@@ -67,8 +67,7 @@ class TrackPlot(Plot):
         """
         
         #Set default properties
-        default_prop={'dots':True,'fillcolor':'category','cmap':None,'levels':None,\
-                      'linecolor':'k','linewidth':1.0,'ms':7.5,'title':True}
+        default_prop={'dots':True,'fillcolor':'category','cmap':None,'levels':None,'linecolor':'k','linewidth':1.0,'ms':7.5}
         default_map_prop={'res':'m','land_color':'#FBF5EA','ocean_color':'#EDFBFF','linewidth':0.5,'linecolor':'k','figsize':(14,9),'dpi':200}
         
         #Initialize plot
@@ -141,75 +140,91 @@ class TrackPlot(Plot):
         else:
             if min(use_lons) < min_lon: min_lon = min(use_lons)
 
-        #Plot background storm line
-        type_line = np.array(['solid' if i in ['SS','SD','TD','TS','HU'] else 'dotted' for i in styp])
-        typenum = np.cumsum([0]+[1 if type_line[i+1]!=j else 0\
-                    for i,j in enumerate(type_line[:-1])])
-        typedict = {k:v for k,v in zip(typenum,type_line)}
-        for i in set(typenum):
-            where = [j for j,k in enumerate(typenum) if k==i]
-            where += [min([where[-1]+1,len(typenum)-1])]
-            self.ax.plot(np.array(lons)[where],np.array(lats)[where],'-',
-                          color='k',linewidth=prop['linewidth']*1.5,linestyle=typedict[i],transform=ccrs.PlateCarree())
+        #Iterate over storm data to plot
+        for i,(i_lat,i_lon,i_vmax,i_mslp,i_date,i_type) in enumerate(zip(storm_data['lat'],lons,storm_data['vmax'],storm_data['mslp'],storm_data['date'],storm_data['type'])):
 
-        #Plot storm line as specified
-        segmented_color = False
-        if prop['linecolor'] == 'category':
-            segmented_color = True
-            ncol = [get_colors_sshws(np.nan_to_num(iwnd)) for iwnd in storm_data['vmax']]
-        elif isinstance(prop['linecolor'],str) and prop['linecolor'] in storm_data.keys():
-            segmented_color = True
-            colorvar = storm_data[prop['linecolor']]
-            if prop['levels'] is None:
-                prop['levels'] = [np.nanmin(colorvar),np.nanmax(colorvar)]
-            cmap,levels = get_cmap_levels(prop['linecolor'],prop['cmap'],prop['levels'])
-            ncol = cmap((colorvar-min(levels))/(max(levels)-min(levels)))
-        if segmented_color:
-            for i in (np.arange(len(lats[1:]))+1):
-                self.ax.plot([lons[i-1],lons[i]],[lats[i-1],lats[i]],
-                              '-',color=ncol[i],linewidth=prop['linewidth'],linestyle='solid',transform=ccrs.PlateCarree())
-        else:
-            self.ax.plot(lons,lats,'-',color=prop['linecolor'],linewidth=prop['linewidth'],transform=ccrs.PlateCarree())
+            #Determine line color, with SSHWS scale used as default
+            if prop['linecolor'] == 'category':
+                segmented_colors = True
+                line_color = get_colors_sshws(np.nan_to_num(i_vmax))
 
-        #Plot storm dots as specified
-        if prop['dots'] == True:
-            segmented_color = False
-            if prop['fillcolor'] == 'category':
-                segmented_color = True
-                ncol = [get_colors_sshws(np.nan_to_num(iwnd)) for iwnd in storm_data['vmax']]
-            elif isinstance(prop['fillcolor'],str) and prop['fillcolor'] in storm_data.keys():
-                segmented_color = True
-                colorvar = storm_data[prop['fillcolor']]
-                if prop['levels'] is None:
-                    prop['levels'] = [np.nanmin(colorvar),np.nanmax(colorvar)]
-                cmap,levels = get_cmap_levels(prop['fillcolor'],prop['cmap'],prop['levels'])
-                ncol = cmap((colorvar-min(levels))/(max(levels)-min(levels)))
-            elif isinstance(prop['fillcolor'],str):
-                ncol = [prop['fillcolor']]*len(sdate)
+            #Use user-defined colormap if another storm variable
+            elif isinstance(prop['linecolor'],str) == True and prop['linecolor'] in ['vmax','mslp']:
+                segmented_colors = True
+                color_variable = storm_data[prop['linecolor']]
+                if prop['levels'] is None: #Auto-determine color levels if needed
+                    prop['levels'] = [np.nanmin(color_variable),np.nanmax(color_variable)]
+                cmap,levels = get_cmap_levels(prop['linecolor'],prop['cmap'],prop['levels'])
+                line_color = cmap((color_variable-min(levels))/(max(levels)-min(levels)))[i]
+
+            #Otherwise go with user input as is
             else:
-                ncol = ['k']*len(sdate)
-            #filter dots to only 6 hour intervals
-            time_hr = np.array([i.strftime('%H%M') for i in sdate])
-            if plot_all == False:
-                time_idx = np.where((time_hr == '0000') | (time_hr == '0600') | (time_hr == '1200') | (time_hr == '1800'))
-                lat_dots = np.array(lats)[time_idx]
-                lon_dots = np.array(lons)[time_idx]
-                vmax_dots = np.array(vmax)[time_idx]
-                type_dots = np.array(styp)[time_idx]
-                ncol = np.array(ncol)[time_idx]
-            else:
-                lat_dots = np.array(lats)
-                lon_dots = np.array(lons)
-                vmax_dots = np.array(vmax)
-                type_dots = np.array(styp)
-            for i,(ilon,ilat,iwnd,itype) in enumerate(zip(lon_dots,lat_dots,vmax_dots,type_dots)):
-                mtype = '^'
-                if itype in ['SD','SS']:
-                    mtype = 's'
-                elif itype in ['TD','TS','HU']:
-                    mtype = 'o'
-                self.ax.plot(ilon,ilat,mtype,color=ncol[i],mec='k',mew=0.5,ms=prop['ms'],transform=ccrs.PlateCarree())
-            
+                segmented_colors = False
+                line_color = prop['linecolor']
+
+            #For tropical/subtropical types, color-code if requested
+            if i > 0:
+                if i_type in ['SD','TD','SS','TS','HU']:
+
+                    #Plot underlying black and overlying colored line
+                    self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],'-',
+                                  linewidth=prop['linewidth']*1.33,color='k',zorder=3,
+                                  transform=ccrs.PlateCarree())
+                    self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],'-',
+                                  linewidth=prop['linewidth'],color=line_color,zorder=4,
+                                  transform=ccrs.PlateCarree())
+
+                #For non-tropical types, plot dotted lines
+                else:
+
+                    #Restrict line width to 1.5 max
+                    line_width = prop['linewidth'] + 0.0
+                    if line_width > 1.5: line_width = 1.5
+
+                    #Plot dotted line
+                    self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],':',
+                                  linewidth=line_width,color=line_color,zorder=4,
+                                  transform=ccrs.PlateCarree(),
+                                  path_effects=[path_effects.Stroke(linewidth=line_width*1.33, foreground='k'),
+                                                path_effects.Normal()])
+
+            #Plot dots if requested
+            if prop['dots'] == True:
+                
+                #Skip if plot_all_dots == False and not in 0,6,12,18z
+                if plot_all_dots == False:
+                    if i_date.strftime('%H%M') not in ['0000','0600','1200','1800']: continue
+
+                #Determine fill color, with SSHWS scale used as default
+                if prop['fillcolor'] == 'category':
+                    segmented_colors = True
+                    fill_color = get_colors_sshws(np.nan_to_num(i_vmax))
+
+                #Use user-defined colormap if another storm variable
+                elif isinstance(prop['fillcolor'],str) == True and prop['fillcolor'] in ['vmax','mslp']:
+                    segmented_colors = True
+                    color_variable = storm_data[prop['fillcolor']]
+                    if prop['levels'] is None: #Auto-determine color levels if needed
+                        prop['levels'] = [np.nanmin(color_variable),np.nanmax(color_variable)]
+                    cmap,levels = get_cmap_levels(prop['fillcolor'],prop['cmap'],prop['levels'])
+                    fill_color = cmap((color_variable-min(levels))/(max(levels)-min(levels)))[i]
+
+                #Otherwise go with user input as is
+                else:
+                    segmented_colors = False
+                    fill_color = prop['fillcolor']
+
+                #Determine dot type
+                marker_type = '^'
+                if i_type in ['SD','SS']:
+                    marker_type = 's'
+                elif i_type in ['TD','TS','HU']:
+                    marker_type = 'o'
+
+                #Plot marker
+                self.ax.plot(i_lon,i_lat,marker_type,mfc=fill_color,mec='k',mew=0.5,
+                             zorder=5,ms=prop['ms'],transform=ccrs.PlateCarree())
+
             #Label track dots
             if track_labels in ['valid_utc']:
                 if track_labels == 'valid_utc':
@@ -218,9 +233,7 @@ class TrackPlot(Plot):
                     track = {t.strftime(strformat):(x,y) for t,x,y in zip(sdate,lons,lats)}
                 self.plot_track_labels(self.ax, labels, track, k=.9)
 
-
         #--------------------------------------------------------------------------------------
-
         
         #Storm-centered plot domain
         if domain == "dynamic" or domain == "dynamic_tropical":
@@ -309,6 +322,8 @@ class TrackPlot(Plot):
         
         credit_text = self.plot_credit()
         self.add_credit(credit_text)
+        
+        #--------------------------------------------------------------------------------------
                 
         #Add legend
         if prop['fillcolor'] == 'category' and prop['dots'] == True:
@@ -334,20 +349,20 @@ class TrackPlot(Plot):
             c5 = mlines.Line2D([], [], linestyle='solid', label='Category 5', color=get_colors_sshws(137))
             self.ax.legend(handles=[ex,td,ts,c1,c2,c3,c4,c5], prop={'size':11.5})
 
-        elif prop['dots'] and not segmented_color:
+        elif prop['dots'] and segmented_colors == False:
             ex = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Non-Tropical', marker='^', color=prop['fillcolor'])
             sb = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Subtropical', marker='s', color=prop['fillcolor'])
             td = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Tropical', marker='o', color=prop['fillcolor'])
             handles=[ex,sb,td]
             self.ax.legend(handles=handles,fontsize=11.5)
 
-        elif not prop['dots'] and not segmented_color:
+        elif prop['dots'] == False and segmented_colors == False:
             ex = mlines.Line2D([], [], linestyle='dotted',label='Non-Tropical', color=prop['linecolor'])
             td = mlines.Line2D([], [], linestyle='solid',label='Tropical', color=prop['linecolor'])
             handles=[ex,td]
             self.ax.legend(handles=handles,fontsize=11.5)
 
-        elif prop['dots']:
+        elif prop['dots'] == True:
             ex = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Non-Tropical', marker='^', color='w')
             sb = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Subtropical', marker='s', color='w')
             td = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Tropical', marker='o', color='w')
@@ -359,7 +374,6 @@ class TrackPlot(Plot):
             
             #Get the bbox
             bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
-            #p = l.get_window_extent()
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
@@ -373,7 +387,7 @@ class TrackPlot(Plot):
             cbar.set_label(prop['fillcolor'],fontsize=11.5,rotation=90)
         
             rect_offset = 0.0
-            if prop['cmap']=='category' and prop['fillcolor']=='vmax':
+            if prop['cmap'] == 'category' and prop['fillcolor'] == 'vmax':
                 cax.yaxis.set_ticks(np.linspace(min(levels),max(levels),len(levels)))
                 cax.yaxis.set_ticklabels(levels)
                 cax2 = cax.twinx()
@@ -397,7 +411,6 @@ class TrackPlot(Plot):
             
             #Get the bbox
             bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
-            #p = l.get_window_extent()
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
@@ -412,7 +425,7 @@ class TrackPlot(Plot):
             cbar.set_label(cbarlab,fontsize=11.5,rotation=90)
         
             rect_offset = 0.0
-            if prop['cmap']=='category' and prop['linecolor']=='vmax':
+            if prop['cmap'] == 'category' and prop['linecolor'] == 'vmax':
                 cax.yaxis.set_ticks(np.linspace(min(levels),max(levels),len(levels)))
                 cax.yaxis.set_ticklabels(levels)
                 cax2 = cax.twinx()
@@ -425,11 +438,11 @@ class TrackPlot(Plot):
             if prop['linecolor'] == 'date':
                 cax.set_yticklabels([f'{mdates.num2date(i):%b %-d}' for i in clevs],fontsize=11.5)
                 
-        
+        #-----------------------------------------------------------------------------------------
         
         #Save image if specified
         if save_path != None and isinstance(save_path,str) == True:
-            plt.savefig(os.path.join(save_path,f"{storm_data['name']}_{storm_data['year']}_track.png"),bbox_inches='tight')
+            plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
         if ax != None or return_ax == True:
@@ -438,7 +451,7 @@ class TrackPlot(Plot):
             plt.show()
             plt.close()
     
-    def plot_storms(self,storms,domain="dynamic",title_text="TC Track Composite",filter_dates=('1/1','12/31'),plot_all_dots=False,ax=None,return_ax=False,save_path=None,prop={},map_prop={}):
+    def plot_storms(self,storms,domain="dynamic",title="TC Track Composite",plot_all_dots=False,labels=False,ax=None,return_ax=False,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of multiple storm tracks.
@@ -466,7 +479,7 @@ class TrackPlot(Plot):
         """
         
         #Set default properties
-        default_prop={'dots':True,'fillcolor':'category','linecolor':'k','category_colors':'default','linewidth':1.0,'ms':7.5}
+        default_prop={'dots':True,'fillcolor':'category','cmap':None,'levels':None,'linecolor':'k','linewidth':1.0,'ms':7.5}
         default_map_prop={'res':'m','land_color':'#FBF5EA','ocean_color':'#EDFBFF','linewidth':0.5,'linecolor':'k','figsize':(14,9),'dpi':200}
         
         #Initialize plot
@@ -527,58 +540,99 @@ class TrackPlot(Plot):
             else:
                 if min(lons) < min_lon: min_lon = min(lons)
 
-            #Plot background storm line
-            type_line = np.array(['solid' if i in ['SS','SD','TD','TS','HU'] else 'dotted' for i in styp])
-            typenum = np.cumsum([0]+[1 if type_line[i+1]!=j else 0\
-                        for i,j in enumerate(type_line[:-1])])
-            typedict = {k:v for k,v in zip(typenum,type_line)}
-            for i in set(typenum):
-                where = [j for j,k in enumerate(typenum) if k==i]
-                where += [min([where[-1]+1,len(typenum)-1])]
-                self.ax.plot(np.array(lons)[where],np.array(lats)[where],'-',
-                              color='k',linewidth=prop['linewidth']*1.5,linestyle=typedict[i],transform=ccrs.PlateCarree())
+            #Add storm label at start and end points
+            if labels == True:
+                self.ax.text(lons[0]+0.0,storm_data['lat'][0]+1.0,f"{storm_data['name'].upper()} {storm_data['year']}",
+                             fontsize=9,clip_on=True,zorder=1000,alpha=0.7,ha='center',va='center')
+                self.ax.text(lons[-1]+0.0,storm_data['lat'][-1]+1.0,f"{storm_data['name'].upper()} {storm_data['year']}",
+                             fontsize=9,clip_on=True,zorder=1000,alpha=0.7,ha='center',va='center')
+            
+            #Iterate over storm data to plot
+            for i,(i_lat,i_lon,i_vmax,i_mslp,i_date,i_type) in enumerate(zip(storm_data['lat'],lons,storm_data['vmax'],storm_data['mslp'],storm_data['date'],storm_data['type'])):
 
-            #Plot storm line as specified
-            if prop['linecolor'] == 'category':
-                type_line = np.array(styp)
-                for i in (np.arange(len(lats[1:]))+1):
-                    ltype = 'solid'
-                    if type_line[i] not in ['SS','SD','TD','TS','HU']: ltype = 'dotted'
-                    self.ax.plot([lons[i-1],lons[i]],[lats[i-1],lats[i]],
-                                  '-',color=get_colors_sshws(np.nan_to_num(vmax[i])),linewidth=prop['linewidth'],linestyle='solid',
-                                  transform=ccrs.PlateCarree())
-            else:
-                self.ax.plot(lons,lats,'-',color=prop['linecolor'],linewidth=prop['linewidth'],transform=ccrs.PlateCarree())
+                #Determine line color, with SSHWS scale used as default
+                if prop['linecolor'] == 'category':
+                    segmented_colors = True
+                    line_color = get_colors_sshws(np.nan_to_num(i_vmax))
 
-            #Plot storm dots as specified
-            if prop['dots'] == True:
-                #filter dots to only 6 hour intervals
-                time_hr = np.array([i.strftime('%H%M') for i in sdate])
-                if plot_all_dots == False:
-                    time_idx = np.where((time_hr == '0000') | (time_hr == '0600') | (time_hr == '1200') | (time_hr == '1800'))
-                    lat_dots = np.array(lats)[time_idx]
-                    lon_dots = np.array(lons)[time_idx]
-                    vmax_dots = np.array(vmax)[time_idx]
-                    type_dots = np.array(styp)[time_idx]
+                #Use user-defined colormap if another storm variable
+                elif isinstance(prop['linecolor'],str) == True and prop['linecolor'] in ['vmax','mslp']:
+                    segmented_colors = True
+                    color_variable = storm_data[prop['linecolor']]
+                    if prop['levels'] is None: #Auto-determine color levels if needed
+                        prop['levels'] = [np.nanmin(color_variable),np.nanmax(color_variable)]
+                    cmap,levels = get_cmap_levels(prop['linecolor'],prop['cmap'],prop['levels'])
+                    line_color = cmap((color_variable-min(levels))/(max(levels)-min(levels)))[i]
+
+                #Otherwise go with user input as is
                 else:
-                    lat_dots = np.array(lats)
-                    lon_dots = np.array(lons)
-                    vmax_dots = np.array(vmax)
-                    type_dots = np.array(styp)
-                for i,(ilon,ilat,iwnd,itype) in enumerate(zip(lon_dots,lat_dots,vmax_dots,type_dots)):
-                    mtype = '^'
-                    if itype in ['SD','SS']:
-                        mtype = 's'
-                    elif itype in ['TD','TS','HU']:
-                        mtype = 'o'
-                    if prop['fillcolor'] == 'category':
-                        ncol = get_colors_sshws(np.nan_to_num(iwnd))
+                    segmented_colors = False
+                    line_color = prop['linecolor']
+
+                #For tropical/subtropical types, color-code if requested
+                if i > 0:
+                    if i_type in ['SD','TD','SS','TS','HU']:
+
+                        #Plot underlying black and overlying colored line
+                        self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],'-',
+                                      linewidth=prop['linewidth']*1.33,color='k',zorder=3,
+                                      transform=ccrs.PlateCarree())
+                        self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],'-',
+                                      linewidth=prop['linewidth'],color=line_color,zorder=4,
+                                      transform=ccrs.PlateCarree())
+
+                    #For non-tropical types, plot dotted lines
                     else:
-                        ncol = 'k'
-                    self.ax.plot(ilon,ilat,mtype,color=ncol,mec='k',mew=0.5,ms=prop['ms'],transform=ccrs.PlateCarree())
+
+                        #Restrict line width to 1.5 max
+                        line_width = prop['linewidth'] + 0.0
+                        if line_width > 1.5: line_width = 1.5
+
+                        #Plot dotted line
+                        self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],':',
+                                      linewidth=line_width,color=line_color,zorder=4,
+                                      transform=ccrs.PlateCarree(),
+                                      path_effects=[path_effects.Stroke(linewidth=line_width*1.33, foreground='k'),
+                                                    path_effects.Normal()])
+
+                #Plot dots if requested
+                if prop['dots'] == True:
+
+                    #Skip if plot_all_dots == False and not in 0,6,12,18z
+                    if plot_all_dots == False:
+                        if i_date.strftime('%H%M') not in ['0000','0600','1200','1800']: continue
+
+                    #Determine fill color, with SSHWS scale used as default
+                    if prop['fillcolor'] == 'category':
+                        segmented_colors = True
+                        fill_color = get_colors_sshws(np.nan_to_num(i_vmax))
+
+                    #Use user-defined colormap if another storm variable
+                    elif isinstance(prop['fillcolor'],str) == True and prop['fillcolor'] in ['vmax','mslp']:
+                        segmented_colors = True
+                        color_variable = storm_data[prop['fillcolor']]
+                        if prop['levels'] is None: #Auto-determine color levels if needed
+                            prop['levels'] = [np.nanmin(color_variable),np.nanmax(color_variable)]
+                        cmap,levels = get_cmap_levels(prop['fillcolor'],prop['cmap'],prop['levels'])
+                        fill_color = cmap((color_variable-min(levels))/(max(levels)-min(levels)))[i]
+
+                    #Otherwise go with user input as is
+                    else:
+                        segmented_colors = False
+                        fill_color = prop['fillcolor']
+
+                    #Determine dot type
+                    marker_type = '^'
+                    if i_type in ['SD','SS']:
+                        marker_type = 's'
+                    elif i_type in ['TD','TS','HU']:
+                        marker_type = 'o'
+
+                    #Plot marker
+                    self.ax.plot(i_lon,i_lat,marker_type,mfc=fill_color,mec='k',mew=0.5,
+                                 zorder=5,ms=prop['ms'],transform=ccrs.PlateCarree())
 
         #--------------------------------------------------------------------------------------
-        
         
         #Storm-centered plot domain
         if domain == "dynamic":
@@ -600,7 +654,7 @@ class TrackPlot(Plot):
         #--------------------------------------------------------------------------------------
         
         #Add left title
-        if title_text != "": self.ax.set_title(f"{title_text}",loc='left',fontsize=17,fontweight='bold')
+        if title != "": self.ax.set_title(f"{title}",loc='left',fontsize=17,fontweight='bold')
 
         #--------------------------------------------------------------------------------------
         
@@ -615,9 +669,10 @@ class TrackPlot(Plot):
         credit_text = self.plot_credit()
         self.add_credit(credit_text)
         
+        #--------------------------------------------------------------------------------------
+                
         #Add legend
-        if prop['fillcolor'] == 'category' or prop['linecolor'] == 'category':
-            
+        if prop['fillcolor'] == 'category' and prop['dots'] == True:
             ex = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Non-Tropical', marker='^', color='w')
             sb = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Subtropical', marker='s', color='w')
             td = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Tropical Depression', marker='o', color=get_colors_sshws(33))
@@ -629,13 +684,115 @@ class TrackPlot(Plot):
             c5 = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Category 5', marker='o', color=get_colors_sshws(137))
             self.ax.legend(handles=[ex,sb,td,ts,c1,c2,c3,c4,c5], prop={'size':11.5})
 
+        elif prop['linecolor'] == 'category' and prop['dots'] == False:
+            ex = mlines.Line2D([], [], linestyle='dotted', label='Non-Tropical', color='k')
+            td = mlines.Line2D([], [], linestyle='solid', label='Sub/Tropical Depression', color=get_colors_sshws(33))
+            ts = mlines.Line2D([], [], linestyle='solid', label='Sub/Tropical Storm', color=get_colors_sshws(34))
+            c1 = mlines.Line2D([], [], linestyle='solid', label='Category 1', color=get_colors_sshws(64))
+            c2 = mlines.Line2D([], [], linestyle='solid', label='Category 2', color=get_colors_sshws(83))
+            c3 = mlines.Line2D([], [], linestyle='solid', label='Category 3', color=get_colors_sshws(96))
+            c4 = mlines.Line2D([], [], linestyle='solid', label='Category 4', color=get_colors_sshws(113))
+            c5 = mlines.Line2D([], [], linestyle='solid', label='Category 5', color=get_colors_sshws(137))
+            self.ax.legend(handles=[ex,td,ts,c1,c2,c3,c4,c5], prop={'size':11.5})
+
+        elif prop['dots'] and segmented_colors == False:
+            ex = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Non-Tropical', marker='^', color=prop['fillcolor'])
+            sb = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Subtropical', marker='s', color=prop['fillcolor'])
+            td = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Tropical', marker='o', color=prop['fillcolor'])
+            handles=[ex,sb,td]
+            self.ax.legend(handles=handles,fontsize=11.5)
+
+        elif prop['dots'] == False and segmented_colors == False:
+            ex = mlines.Line2D([], [], linestyle='dotted',label='Non-Tropical', color=prop['linecolor'])
+            td = mlines.Line2D([], [], linestyle='solid',label='Tropical', color=prop['linecolor'])
+            handles=[ex,td]
+            self.ax.legend(handles=handles,fontsize=11.5)
+
+        elif prop['dots'] == True:
+            ex = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Non-Tropical', marker='^', color='w')
+            sb = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Subtropical', marker='s', color='w')
+            td = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Tropical', marker='o', color='w')
+            handles=[ex,sb,td]
+            for _ in range(7):
+                handles.append(mlines.Line2D([], [], linestyle='-',label='',lw=0))
+            l=self.ax.legend(handles=handles,fontsize=11.5)
+            plt.draw()
+            
+            #Get the bbox
+            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+                
+            #Define colorbar axis
+            cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
+            norm = mlib.colors.Normalize(vmin=min(levels), vmax=max(levels))
+            cbmap = mlib.cm.ScalarMappable(norm=norm, cmap=cmap)
+            cbar = self.fig.colorbar(cbmap,cax=cax,orientation='vertical',\
+                                     ticks=levels)
+            
+            cax.tick_params(labelsize=11.5)
+            cax.yaxis.set_ticks_position('left')
+            cbar.set_label(prop['fillcolor'],fontsize=11.5,rotation=90)
+        
+            rect_offset = 0.0
+            if prop['cmap'] == 'category' and prop['fillcolor'] == 'vmax':
+                cax.yaxis.set_ticks(np.linspace(min(levels),max(levels),len(levels)))
+                cax.yaxis.set_ticklabels(levels)
+                cax2 = cax.twinx()
+                cax2.yaxis.set_ticks_position('right')
+                cax2.yaxis.set_ticks((np.linspace(0,1,len(levels))[:-1]+np.linspace(0,1,len(levels))[1:])*.5)
+                cax2.set_yticklabels(['TD','TS','Cat-1','Cat-2','Cat-3','Cat-4','Cat-5'],fontsize=11.5)
+                cax2.tick_params('both', length=0, width=0, which='major')
+                cax.yaxis.set_ticks_position('left')
+                rect_offset = 0.7
+            if prop['fillcolor'] == 'date':
+                cax.set_yticklabels([f'{mdates.num2date(i):%b %-d}' for i in clevs],fontsize=11.5)
+                
+        else:
+            ex = mlines.Line2D([], [], linestyle='dotted',label='Non-Tropical', color='k')
+            td = mlines.Line2D([], [], linestyle='solid',label='Tropical', color='k')
+            handles=[ex,td]
+            for _ in range(7):
+                handles.append(mlines.Line2D([], [], linestyle='-',label='',lw=0))
+            l=self.ax.legend(handles=handles,fontsize=11.5)
+            plt.draw()
+            
+            #Get the bbox
+            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+                
+            #Define colorbar axis
+            cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
+            norm = mlib.colors.Normalize(vmin=min(levels), vmax=max(levels))
+            cbmap = mlib.cm.ScalarMappable(norm=norm, cmap=cmap)
+            cbar = self.fig.colorbar(cbmap,cax=cax,orientation='vertical',\
+                                     ticks=levels)
+            
+            cax.tick_params(labelsize=11.5)
+            cax.yaxis.set_ticks_position('left')
+            cbarlab = make_var_label(prop['linecolor'],storm_data)            
+            cbar.set_label(cbarlab,fontsize=11.5,rotation=90)
+        
+            rect_offset = 0.0
+            if prop['cmap'] == 'category' and prop['linecolor'] == 'vmax':
+                cax.yaxis.set_ticks(np.linspace(min(levels),max(levels),len(levels)))
+                cax.yaxis.set_ticklabels(levels)
+                cax2 = cax.twinx()
+                cax2.yaxis.set_ticks_position('right')
+                cax2.yaxis.set_ticks((np.linspace(0,1,len(levels))[:-1]+np.linspace(0,1,len(levels))[1:])*.5)
+                cax2.set_yticklabels(['TD','TS','Cat-1','Cat-2','Cat-3','Cat-4','Cat-5'],fontsize=11.5)
+                cax2.tick_params('both', length=0, width=0, which='major')
+                cax.yaxis.set_ticks_position('left')
+                rect_offset = 0.7
+            if prop['linecolor'] == 'date':
+                cax.set_yticklabels([f'{mdates.num2date(i):%b %-d}' for i in clevs],fontsize=11.5)
+                
+        #-----------------------------------------------------------------------------------------
+        
         #Save image if specified
         if save_path != None and isinstance(save_path,str) == True:
-            plt.savefig(os.path.join(save_path,f"tropycal_track_composite.png"),bbox_inches='tight')
+            plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
-        if return_ax == True:
-            return self.ax,'/'.join([str(i) for i in [bound_w,bound_e,bound_s,bound_n]])
+        if ax != None or return_ax == True:
+            return self.ax
         else:
             plt.show()
             plt.close()
@@ -676,7 +833,7 @@ None,prop={},map_prop={}):
         """
         
         #Set default properties
-        default_prop={'dots':True,'fillcolor':'category','linecolor':'k','category_colors':'default','linewidth':1.0,'ms':7.5,'cone_lw':1.0,'cone_alpha':0.6}
+        default_prop={'dots':True,'fillcolor':'category','linecolor':'k','linewidth':1.0,'ms':7.5,'cone_lw':1.0,'cone_alpha':0.6}
         default_map_prop={'res':'m','land_color':'#FBF5EA','ocean_color':'#EDFBFF','linewidth':0.5,'linecolor':'k','figsize':(14,9),'dpi':200}
         
         #Initialize plot
@@ -1335,7 +1492,7 @@ None,prop={},map_prop={}):
 
             #Save image if specified
             if save_path != None and isinstance(save_path,str) == True:
-                plt.savefig(os.path.join(save_path,f"{storm_data['name']}_{storm_data['year']}_track.png"),bbox_inches='tight')
+                plt.savefig(os.path.join(save_path),bbox_inches='tight')
 
             #Return axis if specified, otherwise display figure
             if ax != None or return_ax == True:
@@ -1344,7 +1501,7 @@ None,prop={},map_prop={}):
                 plt.show()
                 plt.close()
     
-    def plot_season(self,season,domain=None,ax=None,return_ax=False,prop={},map_prop={}):
+    def plot_season(self,season,domain=None,ax=None,return_ax=False,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single season.
@@ -1364,8 +1521,8 @@ None,prop={},map_prop={}):
         """
         
         #Set default properties
-        default_prop={'dots':False,'fillcolor':'category','cmap':None,'levels':None,\
-                      'linecolor':'category','linewidth':1.0,'ms':7.5,'title':True}
+        default_prop={'dots':False,'fillcolor':'category','cmap':None,'levels':None,
+                      'linecolor':'category','linewidth':1.0,'ms':7.5}
         default_map_prop={'res':'m','land_color':'#FBF5EA','ocean_color':'#EDFBFF','linewidth':0.5,'linecolor':'k','figsize':(14,9),'dpi':200}
         
         #Initialize plot
@@ -1381,19 +1538,20 @@ None,prop={},map_prop={}):
         max_lon = None
         min_lon = None
 
+        #Iterate over all storms in season object
         sinfo = season.summary()
         storms = season.dict.keys()
-        for istorm in storms:
+        for storm_idx,storm_key in enumerate(storms):
 
             #Get data for this storm
-            storm_data = season.dict[istorm]
+            storm = season.dict[storm_key]
             
             #Retrieve storm data
-            lats = storm_data['lat']
-            lons = storm_data['lon']
-            vmax = storm_data['vmax']
-            styp = storm_data['type']
-            sdate = storm_data['date']
+            lats = storm['lat']
+            lons = storm['lon']
+            vmax = storm['vmax']
+            styp = storm['type']
+            sdate = storm['date']
 
             #Account for cases crossing dateline
             if self.proj.proj4_params['lon_0'] == 180.0:
@@ -1418,76 +1576,94 @@ None,prop={},map_prop={}):
                 min_lon = min(lons)
             else:
                 if min(lons) < min_lon: min_lon = min(lons)
-
-            #Plot background storm line
-            type_line = np.array(['solid' if i in ['SS','SD','TD','TS','HU'] else 'dotted' for i in styp])
-            typenum = np.cumsum([0]+[1 if type_line[i+1]!=j else 0\
-                        for i,j in enumerate(type_line[:-1])])
-            typedict = {k:v for k,v in zip(typenum,type_line)}
-            for i in set(typenum):
-                where = [j for j,k in enumerate(typenum) if k==i]
-                where += [min([where[-1]+1,len(typenum)-1])]
-                self.ax.plot(np.array(lons)[where],np.array(lats)[where],'-',
-                              color='k',linewidth=prop['linewidth']*1.5,linestyle=typedict[i],transform=ccrs.PlateCarree())
-    
-            #Plot storm line as specified
-            segmented_color = False
-            if prop['linecolor'] == 'category':
-                segmented_color = True
-                ncol = [get_colors_sshws(np.nan_to_num(iwnd)) for iwnd in storm_data['vmax']]
-            elif isinstance(prop['linecolor'],str) and prop['linecolor'] in storm_data.keys():
-                segmented_color = True
-                colorvar = storm_data[prop['linecolor']]
-                if prop['levels'] is None:
-                    prop['levels'] = [np.nanmin(colorvar),np.nanmax(colorvar)]
-                cmap,levels = get_cmap_levels(prop['linecolor'],prop['cmap'],prop['levels'])
-                ncol = cmap((colorvar-min(levels))/(max(levels)-min(levels)))
-            if segmented_color:
-                for i in (np.arange(len(lats[1:]))+1):
-                    self.ax.plot([lons[i-1],lons[i]],[lats[i-1],lats[i]],
-                                  '-',color=ncol[i],linewidth=prop['linewidth'],linestyle='solid',transform=ccrs.PlateCarree())
-            else:
-                self.ax.plot(lons,lats,'-',color=prop['linecolor'],linewidth=prop['linewidth'],transform=ccrs.PlateCarree())
-    
-            #Plot storm dots as specified
-            if prop['dots'] == True:
-                segmented_color = False
-                if prop['fillcolor'] == 'category':
-                    segmented_color = True
-                    ncol = [get_colors_sshws(np.nan_to_num(iwnd)) for iwnd in storm_data['vmax']]
-                elif isinstance(prop['fillcolor'],str) and prop['fillcolor'] in storm_data.keys():
-                    segmented_color = True
-                    colorvar = storm_data[prop['fillcolor']]
-                    if prop['levels'] is None:
-                        prop['levels'] = [np.nanmin(colorvar),np.nanmax(colorvar)]
-                    cmap,levels = get_cmap_levels(prop['fillcolor'],prop['cmap'],prop['levels'])
-                    ncol = cmap((colorvar-min(levels))/(max(levels)-min(levels)))
-                elif isinstance(prop['fillcolor'],str):
-                    ncol = [prop['fillcolor']]*len(sdate)
-                else:
-                    ncol = ['k']*len(sdate)
-                #filter dots to only 6 hour intervals
-                time_hr = np.array([i.strftime('%H%M') for i in sdate])
-                if plot_all == False:
-                    time_idx = np.where((time_hr == '0000') | (time_hr == '0600') | (time_hr == '1200') | (time_hr == '1800'))
-                    lat_dots = np.array(lats)[time_idx]
-                    lon_dots = np.array(lons)[time_idx]
-                    vmax_dots = np.array(vmax)[time_idx]
-                    type_dots = np.array(styp)[time_idx]
-                    ncol = np.array(ncol)[time_idx]
-                else:
-                    lat_dots = np.array(lats)
-                    lon_dots = np.array(lons)
-                    vmax_dots = np.array(vmax)
-                    type_dots = np.array(styp)
-                for i,(ilon,ilat,iwnd,itype) in enumerate(zip(lon_dots,lat_dots,vmax_dots,type_dots)):
-                    mtype = '^'
-                    if itype in ['SD','SS']:
-                        mtype = 's'
-                    elif itype in ['TD','TS','HU']:
-                        mtype = 'o'
-                    self.ax.plot(ilon,ilat,mtype,color=ncol[i],mec='k',mew=0.5,ms=prop['ms'],transform=ccrs.PlateCarree())
             
+            #Add storm label at start and end points
+            self.ax.text(lons[0]+0.0,storm['lat'][0]+1.0,storm['name'].upper(),
+                         fontsize=9,clip_on=True,zorder=1000,alpha=0.7,ha='center',va='center')
+            self.ax.text(lons[-1]+0.0,storm['lat'][-1]+1.0,storm['name'].upper(),
+                         fontsize=9,clip_on=True,zorder=1000,alpha=0.7,ha='center',va='center')
+
+            #Iterate over storm data to plot
+            for i,(i_lat,i_lon,i_vmax,i_mslp,i_date,i_type) in enumerate(zip(storm['lat'],lons,storm['vmax'],storm['mslp'],storm['date'],storm['type'])):
+                    
+                #Determine line color, with SSHWS scale used as default
+                if prop['linecolor'] == 'category':
+                    segmented_colors = True
+                    line_color = get_colors_sshws(np.nan_to_num(i_vmax))
+                
+                #Use user-defined colormap if another storm variable
+                elif isinstance(prop['linecolor'],str) == True and prop['linecolor'] in ['vmax','mslp']:
+                    segmented_colors = True
+                    color_variable = storm[prop['linecolor']]
+                    if prop['levels'] is None: #Auto-determine color levels if needed
+                        prop['levels'] = [np.nanmin(color_variable),np.nanmax(color_variable)]
+                    cmap,levels = get_cmap_levels(prop['linecolor'],prop['cmap'],prop['levels'])
+                    line_color = cmap((color_variable-min(levels))/(max(levels)-min(levels)))[i]
+                
+                #Otherwise go with user input as is
+                else:
+                    segmented_colors = False
+                    line_color = prop['linecolor']
+
+                #For tropical/subtropical types, color-code if requested
+                if i > 0:
+                    if i_type in ['SD','TD','SS','TS','HU']:
+
+                        #Plot underlying black and overlying colored line
+                        self.ax.plot([lons[i-1],lons[i]],[storm['lat'][i-1],storm['lat'][i]],'-',
+                                      linewidth=prop['linewidth']*1.33,color='k',zorder=storm_idx*5,
+                                      transform=ccrs.PlateCarree())
+                        self.ax.plot([lons[i-1],lons[i]],[storm['lat'][i-1],storm['lat'][i]],'-',
+                                      linewidth=prop['linewidth'],color=line_color,zorder=i_vmax+(storm_idx*5),
+                                      transform=ccrs.PlateCarree())
+
+                    #For non-tropical types, plot dotted lines
+                    else:
+
+                        #Restrict line width to 1.5 max
+                        line_width = prop['linewidth'] + 0.0
+                        if line_width > 1.5: line_width = 1.5
+
+                        #Plot dotted line
+                        self.ax.plot([lons[i-1],lons[i]],[storm['lat'][i-1],storm['lat'][i]],':',
+                                      linewidth=line_width,color=line_color,zorder=i_vmax+(storm_idx*5),
+                                      transform=ccrs.PlateCarree(),
+                                      path_effects=[path_effects.Stroke(linewidth=line_width*1.33, foreground='k'),
+                                                    path_effects.Normal()])
+                
+                #Plot dots if requested
+                if prop['dots'] == True:
+                    
+                    #Determine fill color, with SSHWS scale used as default
+                    if prop['fillcolor'] == 'category':
+                        segmented_colors = True
+                        fill_color = get_colors_sshws(np.nan_to_num(i_vmax))
+
+                    #Use user-defined colormap if another storm variable
+                    elif isinstance(prop['fillcolor'],str) == True and prop['fillcolor'] in ['vmax','mslp']:
+                        segmented_colors = True
+                        color_variable = storm[prop['fillcolor']]
+                        if prop['levels'] is None: #Auto-determine color levels if needed
+                            prop['levels'] = [np.nanmin(color_variable),np.nanmax(color_variable)]
+                        cmap,levels = get_cmap_levels(prop['fillcolor'],prop['cmap'],prop['levels'])
+                        fill_color = cmap((color_variable-min(levels))/(max(levels)-min(levels)))[i]
+
+                    #Otherwise go with user input as is
+                    else:
+                        segmented_colors = False
+                        fill_color = prop['fillcolor']
+                    
+                    #Determine dot type
+                    marker_type = '^'
+                    if i_type in ['SD','SS']:
+                        marker_type = 's'
+                    elif i_type in ['TD','TS','HU']:
+                        marker_type = 'o'
+                    
+                    #Plot marker
+                    self.ax.plot(i_lon,i_lat,marker_type,mfc=fill_color,mec='k',mew=0.5,
+                                 zorder=900+i_vmax,ms=prop['ms'],transform=ccrs.PlateCarree())
+
         #--------------------------------------------------------------------------------------
         
         #Pre-generated domains
@@ -1496,38 +1672,12 @@ None,prop={},map_prop={}):
         else:
             bound_w,bound_e,bound_s,bound_n = self.set_projection(domain)
             
-        #Determine number of lat/lon lines to use for parallels & meridians
-        self.plot_lat_lon_lines([bound_w,bound_e,bound_s,bound_n])
-        
-        #Add storm labels
-        if season.basin != 'all':
-            for istorm in storms:
-
-                #Get data for this storm
-                storm_data = season.dict[istorm]
-
-                #Retrieve storm data
-                lats = storm_data['lat']
-                lons = storm_data['lon']
-                vmax = storm_data['vmax']
-                styp = storm_data['type']
-                sdate = storm_data['date']
-
-                #Account for cases crossing dateline
-                if self.proj.proj4_params['lon_0'] == 180.0:
-                    new_lons = np.array(lons)
-                    new_lons[new_lons<0] = new_lons[new_lons<0]+360.0
-                    lons = new_lons.tolist()
-
-                #Add storm name at start & end (bound_w = -160, bound_e = -120
-                display_name = storm_data['name']
-                if display_name.lower() == 'unnamed':
-                    display_name = int(storm_data['id'][2:4]) if len(storm_data['id']) == 8 else 'UNNAMED'
-
-                self.ax.text(lons[0],lats[0]+1.0,display_name,alpha=0.7,clip_on=True,
-                             fontweight='bold',fontsize=8.5,color='k',ha='center',va='center',transform=ccrs.PlateCarree())
-                self.ax.text(lons[-1],lats[-1]+1.0,display_name,alpha=0.7,clip_on=True,
-                             fontweight='bold',fontsize=8.5,color='k',ha='center',va='center',transform=ccrs.PlateCarree())
+        #Plot parallels and meridians
+        #This is currently not supported for all cartopy projections.
+        try:
+            self.plot_lat_lon_lines([bound_w,bound_e,bound_s,bound_n])
+        except:
+            pass
         
         #--------------------------------------------------------------------------------------
         
@@ -1562,7 +1712,7 @@ None,prop={},map_prop={}):
         
         #Add plot credit
         warning_text=""
-        if storm_data['source'] == 'ibtracs' and storm_data['source_info'] == 'World Meteorological Organization (official)':
+        if storm['source'] == 'ibtracs' and storm['source_info'] == 'World Meteorological Organization (official)':
             warning_text = f"This plot uses 10-minute averaged WMO official wind data converted\nto 1-minute average (factor of 0.88). Use this wind data with caution.\n\n"
 
             self.ax.text(0.99,0.01,warning_text,fontsize=9,color='k',alpha=0.7,
@@ -1571,6 +1721,8 @@ None,prop={},map_prop={}):
         credit_text = self.plot_credit()
         self.add_credit(credit_text)
                 
+        #--------------------------------------------------------------------------------------
+        
         #Add legend
         if prop['fillcolor'] == 'category' and prop['dots'] == True:
             ex = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Non-Tropical', marker='^', color='w')
@@ -1582,7 +1734,7 @@ None,prop={},map_prop={}):
             c3 = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Category 3', marker='o', color=get_colors_sshws(96))
             c4 = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Category 4', marker='o', color=get_colors_sshws(113))
             c5 = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Category 5', marker='o', color=get_colors_sshws(137))
-            self.ax.legend(handles=[ex,sb,td,ts,c1,c2,c3,c4,c5], prop={'size':11.5})
+            self.ax.legend(handles=[ex,sb,td,ts,c1,c2,c3,c4,c5], prop={'size':11.5}, loc=1)
 
         elif prop['linecolor'] == 'category' and prop['dots'] == False:
             ex = mlines.Line2D([], [], linestyle='dotted', label='Non-Tropical', color='k')
@@ -1593,34 +1745,33 @@ None,prop={},map_prop={}):
             c3 = mlines.Line2D([], [], linestyle='solid', label='Category 3', color=get_colors_sshws(96))
             c4 = mlines.Line2D([], [], linestyle='solid', label='Category 4', color=get_colors_sshws(113))
             c5 = mlines.Line2D([], [], linestyle='solid', label='Category 5', color=get_colors_sshws(137))
-            self.ax.legend(handles=[ex,td,ts,c1,c2,c3,c4,c5], prop={'size':11.5})
+            self.ax.legend(handles=[ex,td,ts,c1,c2,c3,c4,c5], prop={'size':11.5}, loc=1)
 
-        elif prop['dots'] and not segmented_color:
+        elif prop['dots'] == True and segmented_colors == False:
             ex = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Non-Tropical', marker='^', color=prop['fillcolor'])
             sb = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Subtropical', marker='s', color=prop['fillcolor'])
             td = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Tropical', marker='o', color=prop['fillcolor'])
             handles=[ex,sb,td]
-            self.ax.legend(handles=handles,fontsize=11.5)
+            self.ax.legend(handles=handles,fontsize=11.5, prop={'size':11.5}, loc=1)
 
-        elif not prop['dots'] and not segmented_color:
+        elif prop['dots'] == False and segmented_colors == False:
             ex = mlines.Line2D([], [], linestyle='dotted',label='Non-Tropical', color=prop['linecolor'])
             td = mlines.Line2D([], [], linestyle='solid',label='Tropical', color=prop['linecolor'])
             handles=[ex,td]
-            self.ax.legend(handles=handles,fontsize=11.5)
+            self.ax.legend(handles=handles,fontsize=11.5, prop={'size':11.5}, loc=1)
 
-        elif prop['dots']:
+        elif prop['dots'] == True and segmented_colors == True:
             ex = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Non-Tropical', marker='^', color='w')
             sb = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Subtropical', marker='s', color='w')
             td = mlines.Line2D([], [], linestyle='None', ms=prop['ms'], mec='k',mew=0.5, label='Tropical', marker='o', color='w')
             handles=[ex,sb,td]
             for _ in range(7):
                 handles.append(mlines.Line2D([], [], linestyle='-',label='',lw=0))
-            l=self.ax.legend(handles=handles,fontsize=11.5)
+            l = self.ax.legend(handles=handles,fontsize=11.5)
             plt.draw()
             
             #Get the bbox
             bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
-            #p = l.get_window_extent()
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
@@ -1658,7 +1809,6 @@ None,prop={},map_prop={}):
             
             #Get the bbox
             bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
-            #p = l.get_window_extent()
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
@@ -1669,7 +1819,7 @@ None,prop={},map_prop={}):
             
             cax.tick_params(labelsize=11.5)
             cax.yaxis.set_ticks_position('left')
-            cbarlab = make_var_label(prop['linecolor'],storm_data)            
+            cbarlab = make_var_label(prop['linecolor'],storm)            
             cbar.set_label(cbarlab,fontsize=11.5,rotation=90)
         
             rect_offset = 0.0
@@ -1686,6 +1836,11 @@ None,prop={},map_prop={}):
             if prop['linecolor'] == 'date':
                 cax.set_yticklabels([f'{mdates.num2date(i):%b %-d}' for i in clevs],fontsize=11.5)
                 
+        #--------------------------------------------------------------------------------------
+        
+        #Save image if specified
+        if save_path != None and isinstance(save_path,str) == True:
+            plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
         if ax != None or return_ax == True:
@@ -2064,7 +2219,7 @@ None,prop={},map_prop={}):
             "north_atlantic" - North Atlantic Ocean basin
             "pacific" - East/Central Pacific Ocean basin
             "lonW/lonE/latS/latN" - Custom plot domain
-        plot_all : bool
+        plot_all_dots : bool
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -123,19 +123,19 @@ class TrackPlot(Plot):
             use_lats = storm_data['lat']
             use_lons = np.copy(lons).tolist()
         
-        if max_lat == None:
+        if max_lat is None:
             max_lat = max(use_lats)
         else:
             if max(use_lats) > max_lat: max_lat = max(use_lats)
-        if min_lat == None:
+        if min_lat is None:
             min_lat = min(use_lats)
         else:
             if min(use_lats) < min_lat: min_lat = min(use_lats)
-        if max_lon == None:
+        if max_lon is None:
             max_lon = max(use_lons)
         else:
             if max(use_lons) > max_lon: max_lon = max(use_lons)
-        if min_lon == None:
+        if min_lon is None:
             min_lon = min(use_lons)
         else:
             if min(use_lons) < min_lon: min_lon = min(use_lons)
@@ -441,11 +441,11 @@ class TrackPlot(Plot):
         #-----------------------------------------------------------------------------------------
         
         #Save image if specified
-        if save_path != None and isinstance(save_path,str) == True:
+        if save_path is not None and isinstance(save_path,str) == True:
             plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
-        if ax != None or return_ax == True:
+        if ax is not None or return_ax == True:
             return self.ax
         else:
             plt.show()
@@ -523,19 +523,19 @@ class TrackPlot(Plot):
                 lons = new_lons.tolist()
 
             #Add to coordinate extrema
-            if max_lat == None:
+            if max_lat is None:
                 max_lat = max(lats)
             else:
                 if max(lats) > max_lat: max_lat = max(lats)
-            if min_lat == None:
+            if min_lat is None:
                 min_lat = min(lats)
             else:
                 if min(lats) < min_lat: min_lat = min(lats)
-            if max_lon == None:
+            if max_lon is None:
                 max_lon = max(lons)
             else:
                 if max(lons) > max_lon: max_lon = max(lons)
-            if min_lon == None:
+            if min_lon is None:
                 min_lon = min(lons)
             else:
                 if min(lons) < min_lon: min_lon = min(lons)
@@ -787,11 +787,11 @@ class TrackPlot(Plot):
         #-----------------------------------------------------------------------------------------
         
         #Save image if specified
-        if save_path != None and isinstance(save_path,str) == True:
+        if save_path is not None and isinstance(save_path,str) == True:
             plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
-        if ax != None or return_ax == True:
+        if ax is not None or return_ax == True:
             return self.ax
         else:
             plt.show()
@@ -905,19 +905,19 @@ None,prop={},map_prop={}):
 
                 #Add to coordinate extrema
                 if domain != "dynamic_forecast":
-                    if max_lat == None:
+                    if max_lat is None:
                         max_lat = max(lats)
                     else:
                         if max(lats) > max_lat: max_lat = max(lats)
-                    if min_lat == None:
+                    if min_lat is None:
                         min_lat = min(lats)
                     else:
                         if min(lats) < min_lat: min_lat = min(lats)
-                    if max_lon == None:
+                    if max_lon is None:
                         max_lon = max(lons)
                     else:
                         if max(lons) > max_lon: max_lon = max(lons)
-                    if min_lon == None:
+                    if min_lon is None:
                         min_lon = min(lons)
                     else:
                         if min(lons) < min_lon: min_lon = min(lons)
@@ -1064,7 +1064,7 @@ None,prop={},map_prop={}):
                 
             #Add cone coordinates to coordinate extrema
             if 'cone' in forecast.keys() and forecast['cone'] == False:
-                if domain == "dynamic_forecast" or max_lat == None:
+                if domain == "dynamic_forecast" or max_lat is None:
                     max_lat = max(center_lat)
                     min_lat = min(center_lat)
                     max_lon = max(center_lon)
@@ -1075,7 +1075,7 @@ None,prop={},map_prop={}):
                     if max(center_lon) > max_lon: max_lon = max(center_lon)
                     if min(center_lon) < min_lon: min_lon = min(center_lon)
             else:
-                if domain == "dynamic_forecast" or max_lat == None:
+                if domain == "dynamic_forecast" or max_lat is None:
                     max_lat = max(cone_lat)
                     min_lat = min(cone_lat)
                     max_lon = max(cone_lon)
@@ -1219,11 +1219,11 @@ None,prop={},map_prop={}):
         self.add_credit(credit_text)
         
         #Save image if specified
-        if save_path != None and isinstance(save_path,str) == True:
+        if save_path is not None and isinstance(save_path,str) == True:
             plt.savefig(os.path.join(save_path,f"{storm_data['name']}_{storm_data['year']}_track.png"),bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
-        if ax != None or return_ax == True:
+        if ax is not None or return_ax == True:
             return self.ax
         else:
             plt.show()
@@ -1246,11 +1246,11 @@ None,prop={},map_prop={}):
         
         #Initialize plot
         map_prop = self.add_prop(map_prop,default_map_prop)
-        if prop_ensemble_members != None: prop_ensemble_members = self.add_prop(prop_ensemble_members,default_prop_ensemble_members)
-        if prop_ensemble_mean != None: prop_ensemble_mean = self.add_prop(prop_ensemble_mean,default_prop_ensemble_mean)
-        if prop_gfs != None: prop_gfs = self.add_prop(prop_gfs,default_prop_gfs)
-        if prop_ellipse != None: prop_ellipse = self.add_prop(prop_ellipse,default_prop_ellipse)
-        if prop_density != None: prop_density = self.add_prop(prop_density,default_prop_density)
+        if prop_ensemble_members is not None: prop_ensemble_members = self.add_prop(prop_ensemble_members,default_prop_ensemble_members)
+        if prop_ensemble_mean is not None: prop_ensemble_mean = self.add_prop(prop_ensemble_mean,default_prop_ensemble_mean)
+        if prop_gfs is not None: prop_gfs = self.add_prop(prop_gfs,default_prop_gfs)
+        if prop_ellipse is not None: prop_ellipse = self.add_prop(prop_ellipse,default_prop_ellipse)
+        if prop_density is not None: prop_density = self.add_prop(prop_density,default_prop_density)
         self.plot_init(ax,map_prop)
         
         #================================================================================================
@@ -1267,7 +1267,7 @@ None,prop={},map_prop={}):
             #================================================================================================
 
             #Plot density
-            if prop_density != None and hr in ds['gefs']['fhr']:
+            if prop_density is not None and hr in ds['gefs']['fhr']:
 
                 #Create 0.5 degree grid for plotting
                 gridlats = np.arange(0,90,0.25)
@@ -1297,7 +1297,7 @@ None,prop={},map_prop={}):
                 cbar.ax.tick_params(labelsize=12)
 
             #Plot ellipse
-            if hr in ds['gefs']['fhr'] and prop_ellipse != None:
+            if hr in ds['gefs']['fhr'] and prop_ellipse is not None:
                 idx = ds['gefs']['fhr'].index(hr)
 
                 try:
@@ -1327,19 +1327,19 @@ None,prop={},map_prop={}):
                         skip_bounds = True
                 
                 if skip_bounds == False:
-                    if max_lat == None:
+                    if max_lat is None:
                         max_lat = np.nanmax(use_lats)
                     else:
                         if np.nanmax(use_lats) > max_lat: max_lat = np.nanmax(use_lats)
-                    if min_lat == None:
+                    if min_lat is None:
                         min_lat = np.nanmin(use_lats)
                     else:
                         if np.nanmin(use_lats) < min_lat: min_lat = np.nanmin(use_lats)
-                    if max_lon == None:
+                    if max_lon is None:
                         max_lon = np.nanmax(use_lons)
                     else:
                         if np.nanmax(use_lons) > max_lon: max_lon = np.nanmax(use_lons)
-                    if min_lon == None:
+                    if min_lon is None:
                         min_lon = np.nanmin(use_lons)
                     else:
                         if np.nanmin(use_lons) < min_lon: min_lon = np.nanmin(use_lons)
@@ -1375,19 +1375,19 @@ None,prop={},map_prop={}):
                         skip_bounds = True
                 
                 if skip_bounds == False:
-                    if max_lat == None:
+                    if max_lat is None:
                         max_lat = np.nanmax(use_lats)
                     else:
                         if np.nanmax(use_lats) > max_lat: max_lat = np.nanmax(use_lats)
-                    if min_lat == None:
+                    if min_lat is None:
                         min_lat = np.nanmin(use_lats)
                     else:
                         if np.nanmin(use_lats) < min_lat: min_lat = np.nanmin(use_lats)
-                    if max_lon == None:
+                    if max_lon is None:
                         max_lon = np.nanmax(use_lons)
                     else:
                         if np.nanmax(use_lons) > max_lon: max_lon = np.nanmax(use_lons)
-                    if min_lon == None:
+                    if min_lon is None:
                         min_lon = np.nanmin(use_lons)
                     else:
                         if np.nanmin(use_lons) < min_lon: min_lon = np.nanmin(use_lons)
@@ -1419,19 +1419,19 @@ None,prop={},map_prop={}):
                         skip_bounds = True
                 
                 if skip_bounds == False:
-                    if max_lat == None:
+                    if max_lat is None:
                         max_lat = np.nanmax(use_lats)
                     else:
                         if np.nanmax(use_lats) > max_lat: max_lat = np.nanmax(use_lats)
-                    if min_lat == None:
+                    if min_lat is None:
                         min_lat = np.nanmin(use_lats)
                     else:
                         if np.nanmin(use_lats) < min_lat: min_lat = np.nanmin(use_lats)
-                    if max_lon == None:
+                    if max_lon is None:
                         max_lon = np.nanmax(use_lons)
                     else:
                         if np.nanmax(use_lons) > max_lon: max_lon = np.nanmax(use_lons)
-                    if min_lon == None:
+                    if min_lon is None:
                         min_lon = np.nanmin(use_lons)
                     else:
                         if np.nanmin(use_lons) < min_lon: min_lon = np.nanmin(use_lons)
@@ -1459,7 +1459,7 @@ None,prop={},map_prop={}):
 
             #Plot title
             plot_title = f"GEFS Forecast Tracks for {storm_dict['name'].title()}"
-            if prop_density != None: plot_title += f"\nTrack Density ({np.int(prop_density['radius'])}-km radius)"
+            if prop_density is not None: plot_title += f"\nTrack Density ({np.int(prop_density['radius'])}-km radius)"
             self.ax.set_title(plot_title,fontsize=18,loc='left',fontweight='bold')
 
             title_str = f"Hour {hr} | Valid {(forecast+timedelta(hours=hr)).strftime('%H%M UTC %d %B %Y')}\n"
@@ -1491,11 +1491,11 @@ None,prop={},map_prop={}):
             self.add_credit(credit_text)
 
             #Save image if specified
-            if save_path != None and isinstance(save_path,str) == True:
+            if save_path is not None and isinstance(save_path,str) == True:
                 plt.savefig(os.path.join(save_path),bbox_inches='tight')
 
             #Return axis if specified, otherwise display figure
-            if ax != None or return_ax == True:
+            if ax is not None or return_ax == True:
                 return self.ax
             else:
                 plt.show()
@@ -1560,19 +1560,19 @@ None,prop={},map_prop={}):
                 lons = new_lons.tolist()
 
             #Add to coordinate extrema
-            if max_lat == None:
+            if max_lat is None:
                 max_lat = max(lats)
             else:
                 if max(lats) > max_lat: max_lat = max(lats)
-            if min_lat == None:
+            if min_lat is None:
                 min_lat = min(lats)
             else:
                 if min(lats) < min_lat: min_lat = min(lats)
-            if max_lon == None:
+            if max_lon is None:
                 max_lon = max(lons)
             else:
                 if max(lons) > max_lon: max_lon = max(lons)
-            if min_lon == None:
+            if min_lon is None:
                 min_lon = min(lons)
             else:
                 if min(lons) < min_lon: min_lon = min(lons)
@@ -1839,11 +1839,11 @@ None,prop={},map_prop={}):
         #--------------------------------------------------------------------------------------
         
         #Save image if specified
-        if save_path != None and isinstance(save_path,str) == True:
+        if save_path is not None and isinstance(save_path,str) == True:
             plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
-        if ax != None or return_ax == True:
+        if ax is not None or return_ax == True:
             return self.ax
         else:
             plt.show()
@@ -2415,7 +2415,7 @@ None,prop={},map_prop={}):
         self.add_credit(text)
         
         #Return axis if specified, otherwise display figure
-        if ax != None or return_ax == True:
+        if ax is not None or return_ax == True:
             return self.ax
         else:
             plt.show()

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -39,7 +39,7 @@ class TrackPlot(Plot):
         
         self.use_credit = True
     
-    def plot_storm(self,storm,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,track_labels=False,save_path=None,prop={},map_prop={}):
+    def plot_storm(self,storm,domain="dynamic",plot_all_dots=False,ax=None,track_labels=False,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single storm track.
@@ -58,8 +58,6 @@ class TrackPlot(Plot):
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            Whether to return axis at the end of the function. If false, plot will be displayed on the screen. Default is false.
         prop : dict
             Property of storm track lines.
         map_prop : dict
@@ -445,13 +443,9 @@ class TrackPlot(Plot):
             plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
-        if ax is not None or return_ax == True:
-            return self.ax
-        else:
-            plt.show()
-            plt.close()
+        return self.ax
     
-    def plot_storms(self,storms,domain="dynamic",title="TC Track Composite",plot_all_dots=False,labels=False,ax=None,return_ax=False,save_path=None,prop={},map_prop={}):
+    def plot_storms(self,storms,domain="dynamic",title="TC Track Composite",plot_all_dots=False,labels=False,ax=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of multiple storm tracks.
@@ -470,8 +464,6 @@ class TrackPlot(Plot):
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            Whether to return axis at the end of the function. If false, plot will be displayed on the screen. Default is false.
         prop : dict
             Property of storm track lines.
         map_prop : dict
@@ -791,13 +783,9 @@ class TrackPlot(Plot):
             plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
-        if ax is not None or return_ax == True:
-            return self.ax
-        else:
-            plt.show()
-            plt.close()
+        return self.ax
         
-    def plot_storm_nhc(self,forecast,track=None,track_labels='fhr',cone_days=5,domain="dynamic_forecast",ax=None,return_ax=False,save_path=
+    def plot_storm_nhc(self,forecast,track=None,track_labels='fhr',cone_days=5,domain="dynamic_forecast",ax=None,save_path=
 None,prop={},map_prop={}):
         
         r"""
@@ -824,8 +812,6 @@ None,prop={},map_prop={}):
             "lonW/lonE/latS/latN" - Custom plot domain
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            Whether to return axis at the end of the function. If false, plot will be displayed on the screen. Default is false.
         prop : dict
             Property of storm track lines.
         map_prop : dict
@@ -1223,14 +1209,10 @@ None,prop={},map_prop={}):
             plt.savefig(os.path.join(save_path,f"{storm_data['name']}_{storm_data['year']}_track.png"),bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
-        if ax is not None or return_ax == True:
-            return self.ax
-        else:
-            plt.show()
-            plt.close()
+        return self.ax
 
     def plot_ensembles(self,forecast,storm_dict,fhr,prop_ensemble_members,prop_ensemble_mean,prop_gfs,prop_ellipse,prop_density,nens,
-                       domain,ds,ax,return_ax,map_prop,save_path):
+                       domain,ds,ax,map_prop,save_path):
         
         r"""
         
@@ -1495,13 +1477,9 @@ None,prop={},map_prop={}):
                 plt.savefig(os.path.join(save_path),bbox_inches='tight')
 
             #Return axis if specified, otherwise display figure
-            if ax is not None or return_ax == True:
-                return self.ax
-            else:
-                plt.show()
-                plt.close()
+            return self.ax
     
-    def plot_season(self,season,domain=None,ax=None,return_ax=False,save_path=None,prop={},map_prop={}):
+    def plot_season(self,season,domain=None,ax=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single season.
@@ -1512,8 +1490,6 @@ None,prop={},map_prop={}):
             Instance of Season.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            Whether to return axis at the end of the function. If false, plot will be displayed on the screen. Default is false.
         prop : dict
             Property of storm track lines.
         map_prop : dict
@@ -1843,11 +1819,7 @@ None,prop={},map_prop={}):
             plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis if specified, otherwise display figure
-        if ax is not None or return_ax == True:
-            return self.ax
-        else:
-            plt.show()
-            plt.close()
+        return self.ax
         
     def generate_nhc_cone(self,forecast,dateline,cone_days=5,cone_year=None):
         
@@ -2205,7 +2177,7 @@ None,prop={},map_prop={}):
                                         color='k'),
                         transform=ccrs.PlateCarree(),clip_on=True)
 
-    def plot_gridded(self,xcoord,ycoord,zcoord,varname='type',VEC_FLAG=False,domain="north_atlantic",ax=None,return_ax=False,prop={},map_prop={}):
+    def plot_gridded(self,xcoord,ycoord,zcoord,varname='type',VEC_FLAG=False,domain="north_atlantic",ax=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of a single storm track.
@@ -2223,8 +2195,6 @@ None,prop={},map_prop={}):
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            Whether to return axis at the end of the function. If false, plot will be displayed on the screen. Default is false.
         prop : dict
             Property of storm track lines.
         map_prop : dict
@@ -2415,10 +2385,6 @@ None,prop={},map_prop={}):
         self.add_credit(text)
         
         #Return axis if specified, otherwise display figure
-        if ax is not None or return_ax == True:
-            return self.ax
-        else:
-            plt.show()
-            plt.close()
+        return self.ax
 
 

--- a/src/tropycal/tracks/season.py
+++ b/src/tropycal/tracks/season.py
@@ -286,7 +286,7 @@ class Season:
             self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
-        plot_ax = self.plot_obj.plot_season(season,domain,ax=ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_season(self,domain,ax=ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
         return plot_ax

--- a/src/tropycal/tracks/season.py
+++ b/src/tropycal/tracks/season.py
@@ -60,7 +60,7 @@ class Season:
         new_coords = self.coords.copy()
         
         #Add year to list of years
-        if isinstance(self.coords['year'],int) == True:
+        if isinstance(self.coords['year'],int):
             new_coords['year'] = [self.year,new.year]
         else:
             new_coords['year'].append(new.year)
@@ -233,15 +233,15 @@ class Season:
         """
         
         #Check if storm is str or tuple
-        if isinstance(storm, str) == True:
+        if isinstance(storm, str):
             key = storm
-        elif isinstance(storm, tuple) == True:
+        elif isinstance(storm, tuple):
             key = self.get_storm_id((storm[0],storm[1]))
         else:
             raise RuntimeError("Storm must be a string (e.g., 'AL052019') or tuple (e.g., ('Matthew',2016)).")
         
         #Retrieve key of given storm
-        if isinstance(key, str) == True:
+        if isinstance(key, str):
             return Storm(self.dict[key])
         else:
             error_message = ''.join([f"\n{i}" for i in key])

--- a/src/tropycal/tracks/season.py
+++ b/src/tropycal/tracks/season.py
@@ -286,7 +286,7 @@ class Season:
         return_ax = self.plot_obj.plot_season(season,domain,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax != None or return_ax == True: return return_ax
+        if ax is not None or return_ax == True: return return_ax
         
     def summary(self):
         

--- a/src/tropycal/tracks/season.py
+++ b/src/tropycal/tracks/season.py
@@ -248,7 +248,7 @@ class Season:
             error_message = f"Multiple IDs were identified for the requested storm. Choose one of the following storm IDs and provide it as the 'storm' argument instead of a tuple:{error_message}"
             raise RuntimeError(error_message)
         
-    def plot(self,domain=None,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+    def plot(self,domain=None,ax=None,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of this season.
@@ -259,8 +259,6 @@ class Season:
             Domain for the plot. Default is basin-wide. Please refer to :ref:`options-domain` for available domain options.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         save_path : str
@@ -272,6 +270,11 @@ class Season:
             Customization properties of storm track lines. Please refer to :ref:`options-prop` for available options.
         map_prop : dict
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         """
 
         #Create instance of plot object
@@ -283,10 +286,10 @@ class Season:
             self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
-        return_ax = self.plot_obj.plot_season(season,domain,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_season(season,domain,ax=ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax is not None or return_ax == True: return return_ax
+        return plot_ax
         
     def summary(self):
         

--- a/src/tropycal/tracks/season.py
+++ b/src/tropycal/tracks/season.py
@@ -248,19 +248,23 @@ class Season:
             error_message = f"Multiple IDs were identified for the requested storm. Choose one of the following storm IDs and provide it as the 'storm' argument instead of a tuple:{error_message}"
             raise RuntimeError(error_message)
         
-    def plot(self,subset=None,domain=None,ax=None,return_ax=False,cartopy_proj=None,prop={},map_prop={}):
+    def plot(self,domain=None,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of this season.
         
         Parameters
         ----------
+        domain : str
+            Domain for the plot. Default is basin-wide. Please refer to :ref:`options-domain` for available domain options.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
         return_ax : bool
             If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
+        save_path : str
+            Relative or full path of directory to save the image in. If none, image will not be saved.
         
         Other Parameters
         ----------------
@@ -269,15 +273,7 @@ class Season:
         map_prop : dict
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
         """
-        
-        season = copy(self)
-        stormkeys = list(season.dict.keys())
-        
-        if subset is not None:
-            subkeys = [stormskeys[i] for i in subset]
-            season.dict = {key: value for key, value in season.dict.items() if key in subkeys}
-            
-        
+
         #Create instance of plot object
         self.plot_obj = TrackPlot()
         
@@ -287,7 +283,7 @@ class Season:
             self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
-        return_ax = self.plot_obj.plot_season(season,domain,ax=ax,return_ax=return_ax,prop=prop,map_prop=map_prop)
+        return_ax = self.plot_obj.plot_season(season,domain,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
         if ax != None or return_ax == True: return return_ax

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -608,7 +608,7 @@ class Storm:
         #Return dataset
         return ds
     
-    def plot(self,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+    def plot(self,domain="dynamic",plot_all_dots=False,ax=None,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of the observed track of the storm.
@@ -621,8 +621,6 @@ class Storm:
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         save_path : str
@@ -634,6 +632,11 @@ class Storm:
             Customization properties of storm track lines. Please refer to :ref:`options-prop` for available options.
         map_prop : dict
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         """
         
         #Create instance of plot object
@@ -651,14 +654,14 @@ class Storm:
             self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
-        plot_ax = self.plot_obj.plot_storm(self.dict,domain,plot_all_dots,ax=ax,return_ax=return_ax,prop=prop,map_prop=map_prop,save_path=save_path)
+        plot_ax = self.plot_obj.plot_storm(self.dict,domain,plot_all_dots,ax=ax,prop=prop,map_prop=map_prop,save_path=save_path)
         
         #Return axis
-        if ax is not None or return_ax == True: return plot_ax
+        return plot_ax
         
     #PLOT FUNCTION FOR HURDAT
     def plot_nhc_forecast(self,forecast,track_labels='fhr',cone_days=5,domain="dynamic_forecast",
-                          ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+                          ax=None,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of the operational NHC forecast track along with observed track data.
@@ -680,8 +683,6 @@ class Storm:
             Domain for the plot. Default is "dynamic_forecast". Please refer to :ref:`options-domain` for available domain options.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         save_path : str
@@ -693,6 +694,11 @@ class Storm:
             Customization properties of NHC forecast plot. Please refer to :ref:`options-prop-nhc` for available options.
         map_prop : dict
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         """
         
         #Check to ensure the data source is HURDAT
@@ -821,10 +827,10 @@ class Storm:
         forecast_dict['basin'] = self.basin
         
         #Plot storm
-        plot_ax = self.plot_obj.plot_storm_nhc(forecast_dict,track_dict,track_labels,cone_days,domain,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
+        plot_ax = self.plot_obj.plot_storm_nhc(forecast_dict,track_dict,track_labels,cone_days,domain,ax=ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax is not None or return_ax == True: return plot_ax
+        return plot_ax
         
     
     #PLOT FUNCTION FOR HURDAT
@@ -834,7 +840,7 @@ class Storm:
                             prop_gfs = {'linewidth':2.0, 'linecolor':'b'},
                             prop_ellipse = {'linewidth':2.0, 'linecolor':'r'},
                             prop_density = {'radius':200, 'cmap':plt.cm.YlOrRd, 'levels':[i for i in range(5,105,5)]},
-                            domain="dynamic",ax=None,return_ax=False,cartopy_proj=None,save_path=None,map_prop={}):
+                            domain="dynamic",ax=None,cartopy_proj=None,save_path=None,map_prop={}):
         
         r"""
         (Add track history like we do for NHC forecasts)
@@ -854,8 +860,6 @@ class Storm:
             Domain for the plot. Default is "dynamic". Please refer to :ref:`options-domain` for available domain options.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         save_path : str
@@ -867,6 +871,11 @@ class Storm:
             Customization properties of storm track lines. Please refer to :ref:`options-prop` for available options.
         map_prop : dict
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         """
         
         #Create instance of plot object
@@ -983,10 +992,10 @@ class Storm:
             fhr = [fhr]
         
         #Plot storm
-        plot_ax = self.plot_obj.plot_ensembles(forecast,self.dict,fhr,prop_members,prop_mean,prop_gfs,prop_ellipse,prop_density,nens,domain,ds,ax=ax,return_ax=return_ax,map_prop=map_prop,save_path=save_path)
+        plot_ax = self.plot_obj.plot_ensembles(forecast,self.dict,fhr,prop_members,prop_mean,prop_gfs,prop_ellipse,prop_density,nens,domain,ds,ax=ax,map_prop=map_prop,save_path=save_path)
         
         #Return axis
-        if ax is not None or return_ax == True: return plot_ax
+        return plot_ax
     
     def list_nhc_discussions(self):
         
@@ -1696,7 +1705,7 @@ class Storm:
 
             
     def plot_tors(self,dist_thresh=1000,Tors=None,domain="dynamic",plotPPH=False,plot_all=False,\
-                  ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+                  ax=None,cartopy_proj=None,save_path=None,prop={},map_prop={}):
                 
         r"""
         Creates a plot of the storm and associated tornado tracks.
@@ -1721,13 +1730,10 @@ class Storm:
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
         save_path : str
             Relative or full path of directory to save the image in. If none, image will not be saved.
-        
         
         Other Parameters
         ----------------
@@ -1735,6 +1741,11 @@ class Storm:
             Customization properties of plot.
         map_prop : dict
             Customization properties of Cartopy map. Please refer to :ref:`options-map-prop` for available options.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         """
         
         #Set default colormap for TC plots to Wistia
@@ -1792,19 +1803,14 @@ class Storm:
         storm_title = plot_ax.get_title('left')
         plot_ax.set_title(f'{storm_title}\n{tor_title}',loc='left',fontsize=17,fontweight='bold')
         
+        #Save plot
+        if save_path is not None and isinstance(save_path,str) == True:
+            plt.savefig(save_path,bbox_inches='tight')
+        
         #Return axis
-        if ax is not None or return_ax == True: 
-            return plot_ax
-        else:
-            #Save image if specified
-            if save_path is not None and isinstance(save_path,str) == True:
-                plt.savefig(save_path,bbox_inches='tight')
-            else:
-                plt.show()
-            plt.close()
+        return plot_ax
 
-
-    def plot_TCtors_rotated(self,dist_thresh=1000,return_ax=False,save_path=None):
+    def plot_TCtors_rotated(self,dist_thresh=1000,save_path=None):
         
         r"""
         Plot tracks of tornadoes relative to the storm motion vector of the tropical cyclone.
@@ -1813,10 +1819,13 @@ class Storm:
         ----------
         dist_thresh : int
             Distance threshold (in kilometers) from the tropical cyclone track over which to attribute tornadoes to the TC. Default is 1000 km. Ignored if tornado data was passed into Storm from TrackDataset.
-        return_ax : bool
-            If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         save_path : str
             Relative or full path of directory to save the image in. If none, image will not be saved.
+        
+        Returns
+        -------
+        ax
+            Instance of axes containing the plot is returned.
         
         Notes
         -----
@@ -1877,15 +1886,12 @@ class Storm:
         ax.text(0.99,0.01,plot_credit(),fontsize=8,color='k',alpha=0.7,
                 transform=ax.transAxes,ha='right',va='bottom',zorder=10)
         
+        #Save plot
+        if save_path is not None and isinstance(save_path,str) == True:
+            plt.savefig(save_path,bbox_inches='tight')
+        
         #Return axis or show figure
-        if return_ax == True:
-            return ax
-        else:
-            if save_path is not None and isinstance(save_path,str) == True:
-                plt.savefig(save_path,bbox_inches='tight')
-            else:
-                plt.show()
-            plt.close()
+        return ax
             
     def get_recon(self,deltap_thresh=8,save_path="",read_path="",mission_url_list=None,update=False):
         

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -572,6 +572,11 @@ class Storm:
         r"""
         Converts the storm dict into a pandas DataFrame object.
         
+        Parameters
+        ----------
+        attrs_as_columns : bool
+            If True, adds Storm object attributes as columns in the DataFrame returned. Default is False.
+        
         Returns
         -------
         pandas.DataFrame

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -643,13 +643,12 @@ class Storm:
             self.plot_obj = TrackPlot()
         
         #Create cartopy projection
-        if cartopy_proj is None:
-            if max(self.dict['lon']) > 150 or min(self.dict['lon']) < -150:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
-            else:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
-        else:
+        if cartopy_proj is not None:
             self.plot_obj.proj = cartopy_proj
+        elif max(self.dict['lon']) > 150 or min(self.dict['lon']) < -150:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
+        else:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
             
         #Plot storm
         plot_ax = self.plot_obj.plot_storm(self.dict,domain,plot_all_dots,ax=ax,return_ax=return_ax,prop=prop,map_prop=map_prop,save_path=save_path)
@@ -877,13 +876,12 @@ class Storm:
             self.plot_obj = TrackPlot()
         
         #Create cartopy projection
-        if cartopy_proj is None:
-            if max(self.dict['lon']) > 150 or min(self.dict['lon']) < -150:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
-            else:
-                self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
-        else:
+        if cartopy_proj is not None:
             self.plot_obj.proj = cartopy_proj
+        elif max(self.dict['lon']) > 150 or min(self.dict['lon']) < -150:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
+        else:
+            self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=0.0)
         
         #-------------------------------------------------------------------------
         

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -69,7 +69,7 @@ class Storm:
         
         #Format keys for summary
         type_array = np.array(self.dict['type'])
-        if self.invest == True: idx = np.array([True for i in type_array])
+        if self.invest: idx = np.array([True for i in type_array])
         idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))[0]
         if len(idx) == 0:
             start_date = 'N/A'
@@ -140,7 +140,7 @@ class Storm:
                     self[key] = np.array(self.dict[key])
 
             #Assign tornado data
-            if stormTors is not None and isinstance(stormTors,dict) == True:
+            if stormTors is not None and isinstance(stormTors,dict):
                 self.stormTors = stormTors['data']
                 self.tornado_dist_thresh = stormTors['dist_thresh']
                 self.coords['Tornado Count'] = len(stormTors['data'])
@@ -152,7 +152,7 @@ class Storm:
                 pass
 
             #Determine if storm object was retrieved via realtime object
-            if 'realtime' in keys and self.dict['realtime'] == True:
+            if 'realtime' in keys and self.dict['realtime']:
                 self.realtime = True
                 self.coords['realtime'] = True
             else:
@@ -160,7 +160,7 @@ class Storm:
                 self.coords['realtime'] = False
             
             #Determine if storm object is an invest
-            if 'invest' in keys and self.dict['invest'] == True:
+            if 'invest' in keys and self.dict['invest']:
                 self.invest = True
                 self.coords['invest'] = True
             else:
@@ -463,7 +463,7 @@ class Storm:
 
         #Construct new storm dict with subset elements
         for key in NEW_STORM.dict.keys():
-            if isinstance(NEW_STORM.dict[key], list) == True:
+            if isinstance(NEW_STORM.dict[key], list):
                 NEW_STORM.dict[key] = [NEW_STORM.dict[key][i] for i in idx_final]
             else:
                 NEW_STORM.dict[key] = NEW_STORM.dict[key]
@@ -556,7 +556,7 @@ class Storm:
         #Add every key containing a list into the dict, otherwise add as an attribute
         keys = [k for k in self.dict.keys() if k != 'date']
         for key in keys:
-            if isinstance(self.dict[key], list) == True:
+            if isinstance(self.dict[key], list):
                 ds[key] = xr.DataArray(self.dict[key],coords=[time],dims=['time'])
             else:
                 attrs[key] = self.dict[key]
@@ -596,7 +596,7 @@ class Storm:
         #Add every key containing a list into the dict
         keys = [k for k in self.dict.keys()]
         for key in keys:
-            if isinstance(self.dict[key], list) == True:
+            if isinstance(self.dict[key], list):
                 ds[key] = self.dict[key]
             else:
                 if attrs_as_columns:
@@ -706,7 +706,7 @@ class Storm:
             raise RuntimeError("Error: NHC data can only be accessed when HURDAT is used as the data source.")
         
         #Check to ensure storm is not an invest
-        if self.invest == True:
+        if self.invest:
             raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Create instance of plot object
@@ -737,10 +737,10 @@ class Storm:
         carq_forecast_init = [k for k in carq_forecasts.keys()]
 
         #Find closest matching time to the provided forecast date, or time
-        if isinstance(forecast,int) == True:
+        if isinstance(forecast,int):
             forecast_dict = nhc_forecasts[nhc_forecast_init[forecast-1]]
             advisory_num = forecast+0
-        elif isinstance(forecast,dt) == True:
+        elif isinstance(forecast,dt):
             nhc_forecast_init_dt = [dt.strptime(k,'%Y%m%d%H') for k in nhc_forecast_init]
             time_diff = np.array([(i-forecast).days + (i-forecast).seconds/86400 for i in nhc_forecast_init_dt])
             closest_idx = np.abs(time_diff).argmin()
@@ -1013,7 +1013,7 @@ class Storm:
             raise RuntimeError("Error: NHC data can only be accessed when HURDAT is used as the data source.")
         
         #Check to ensure storm is not an invest
-        if self.invest == True:
+        if self.invest:
             raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Get storm ID & corresponding data URL
@@ -1336,7 +1336,7 @@ class Storm:
             raise RuntimeError(msg)
         
         #Check to ensure storm is not an invest
-        if self.invest == True:
+        if self.invest:
             raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Get storm ID & corresponding data URL
@@ -1356,7 +1356,7 @@ class Storm:
         #Get list of storm discussions
         disco_dict = self.list_nhc_discussions()
         
-        if isinstance(forecast,dt) == True:
+        if isinstance(forecast,dt):
             #Find closest discussion to the time provided
             disco_times = disco_dict['utc_date']
             disco_ids = [int(i) for i in disco_dict['id']]
@@ -1370,7 +1370,7 @@ class Storm:
             if np.abs(closest_diff) >= 1.0:
                 warnings.warn(f"The date provided is unavailable or outside of the duration of the storm. Use the \"list_nhc_discussions()\" function to retrieve a list of available NHC discussions for this storm. Returning the closest available NHC discussion.")
                 
-        if isinstance(forecast,int) == True:
+        if isinstance(forecast,int):
             #Find closest discussion ID to the one provided
             disco_times = disco_dict['utc_date']
             disco_ids = [int(i) for i in disco_dict['id']]
@@ -1470,7 +1470,7 @@ class Storm:
             raise RuntimeError(msg)
         
         #Check to ensure storm is not an invest
-        if self.invest == True:
+        if self.invest:
             raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Get storm ID & corresponding data URL
@@ -1484,7 +1484,7 @@ class Storm:
         if isinstance(query,str) == False and isinstance(query,list) == False:
             msg = "'query' must be of type str or list."
             raise TypeError(msg)
-        if isinstance(query,list) == True:
+        if isinstance(query,list):
             for i in query:
                 if isinstance(i,str) == False:
                     msg = "Entries of list 'query' must be of type str."
@@ -1504,13 +1504,13 @@ class Storm:
             text = forecast['text'].lower()
             
             #If found, add into list
-            if isinstance(query,str) == True:
+            if isinstance(query,str):
                 if text.find(query.lower()) >= 0: output.append(forecast)
             else:
                 found = False
                 for i_query in query:
                     if text.find(i_query.lower()) >= 0: found = True
-                if found == True: output.append(forecast)
+                if found: output.append(forecast)
             
         #Return list
         return output
@@ -1672,7 +1672,7 @@ class Storm:
         """
         
         #Check to ensure storm is not an invest
-        if self.invest == True:
+        if self.invest:
             raise RuntimeError("Error: NHC does not issue advisories for invests that have not been designated as Potential Tropical Cyclones.")
         
         #Error check
@@ -1804,7 +1804,7 @@ class Storm:
         plot_ax.set_title(f'{storm_title}\n{tor_title}',loc='left',fontsize=17,fontweight='bold')
         
         #Save plot
-        if save_path is not None and isinstance(save_path,str) == True:
+        if save_path is not None and isinstance(save_path,str):
             plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis
@@ -1887,7 +1887,7 @@ class Storm:
                 transform=ax.transAxes,ha='right',va='bottom',zorder=10)
         
         #Save plot
-        if save_path is not None and isinstance(save_path,str) == True:
+        if save_path is not None and isinstance(save_path,str):
             plt.savefig(save_path,bbox_inches='tight')
         
         #Return axis or show figure

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -140,7 +140,7 @@ class Storm:
                     self[key] = np.array(self.dict[key])
 
             #Assign tornado data
-            if stormTors != None and isinstance(stormTors,dict) == True:
+            if stormTors is not None and isinstance(stormTors,dict) == True:
                 self.stormTors = stormTors['data']
                 self.tornado_dist_thresh = stormTors['dist_thresh']
                 self.coords['Tornado Count'] = len(stormTors['data'])
@@ -643,7 +643,7 @@ class Storm:
             self.plot_obj = TrackPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             if max(self.dict['lon']) > 150 or min(self.dict['lon']) < -150:
                 self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
             else:
@@ -655,7 +655,7 @@ class Storm:
         plot_ax = self.plot_obj.plot_storm(self.dict,domain,plot_all_dots,ax=ax,return_ax=return_ax,prop=prop,map_prop=map_prop,save_path=save_path)
         
         #Return axis
-        if ax != None or return_ax == True: return plot_ax
+        if ax is not None or return_ax == True: return plot_ax
         
     #PLOT FUNCTION FOR HURDAT
     def plot_nhc_forecast(self,forecast,track_labels='fhr',cone_days=5,domain="dynamic_forecast",
@@ -711,7 +711,7 @@ class Storm:
             self.plot_obj = TrackPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             if max(self.dict['lon']) > 140 or min(self.dict['lon']) < -140:
                 self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
             else:
@@ -825,7 +825,7 @@ class Storm:
         plot_ax = self.plot_obj.plot_storm_nhc(forecast_dict,track_dict,track_labels,cone_days,domain,ax=ax,return_ax=return_ax,save_path=save_path,prop=prop,map_prop=map_prop)
         
         #Return axis
-        if ax != None or return_ax == True: return plot_ax
+        if ax is not None or return_ax == True: return plot_ax
         
     
     #PLOT FUNCTION FOR HURDAT
@@ -877,7 +877,7 @@ class Storm:
             self.plot_obj = TrackPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             if max(self.dict['lon']) > 150 or min(self.dict['lon']) < -150:
                 self.plot_obj.create_cartopy(proj='PlateCarree',central_longitude=180.0)
             else:
@@ -975,7 +975,7 @@ class Storm:
                 ds['gefs']['members'].append(len(temp_data['lat']))
 
                 #Calculate ellipse data
-                if prop_ellipse != None:
+                if prop_ellipse is not None:
                     ellipse_data = plot_ellipse(temp_data['lat'],temp_data['lon'])
                     ds['gefs']['ellipse_lon'].append(ellipse_data['xell'])
                     ds['gefs']['ellipse_lat'].append(ellipse_data['yell'])
@@ -988,7 +988,7 @@ class Storm:
         plot_ax = self.plot_obj.plot_ensembles(forecast,self.dict,fhr,prop_members,prop_mean,prop_gfs,prop_ellipse,prop_density,nens,domain,ds,ax=ax,return_ax=return_ax,map_prop=map_prop,save_path=save_path)
         
         #Return axis
-        if ax != None or return_ax == True: return plot_ax
+        if ax is not None or return_ax == True: return plot_ax
     
     def list_nhc_discussions(self):
         
@@ -1430,7 +1430,7 @@ class Storm:
             response.close()
         
         #Save file, if specified
-        if save_path != None:
+        if save_path is not None:
             closest_time = disco_times[closest_idx].strftime("%Y%m%d_%H%M")
             fname = f"nhc_disco_{self.name.lower()}_{self.year}_{closest_time}.txt"
             o = open(save_path+fname,"w")
@@ -1745,7 +1745,7 @@ class Storm:
         except:
             prop['PPHcolors']='Wistia'
         
-        if Tors == None:
+        if Tors is None:
             try:
                 self.stormTors
             except:
@@ -1773,7 +1773,7 @@ class Storm:
             self.plot_obj_tor = TornadoPlot()
         
         #Create cartopy projection
-        if cartopy_proj == None:
+        if cartopy_proj is None:
             if max(self.dict['lon']) > 150 or min(self.dict['lon']) < -150:
                 self.plot_obj_tor.create_cartopy(proj='PlateCarree',central_longitude=180.0)
                 self.plot_obj_tc.create_cartopy(proj='PlateCarree',central_longitude=180.0)
@@ -1795,11 +1795,11 @@ class Storm:
         plot_ax.set_title(f'{storm_title}\n{tor_title}',loc='left',fontsize=17,fontweight='bold')
         
         #Return axis
-        if ax != None or return_ax == True: 
+        if ax is not None or return_ax == True: 
             return plot_ax
         else:
             #Save image if specified
-            if save_path != None and isinstance(save_path,str) == True:
+            if save_path is not None and isinstance(save_path,str) == True:
                 plt.savefig(save_path,bbox_inches='tight')
             else:
                 plt.show()
@@ -1883,7 +1883,7 @@ class Storm:
         if return_ax == True:
             return ax
         else:
-            if save_path != None and isinstance(save_path,str) == True:
+            if save_path is not None and isinstance(save_path,str) == True:
                 plt.savefig(save_path,bbox_inches='tight')
             else:
                 plt.show()

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -495,8 +495,8 @@ class Storm:
         
         Returns
         -------
-        storm object
-            New storm object containing the updated dictionary.
+        tropycal.tracks.Storm
+            New Storm object containing the updated dictionary.
         """
         
         NEW_STORM = copy.copy(self)
@@ -600,8 +600,7 @@ class Storm:
         #Return dataset
         return ds
     
-    #PLOT FUNCTION FOR HURDAT
-    def plot(self,domain="dynamic",plot_all=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
+    def plot(self,domain="dynamic",plot_all_dots=False,ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
         
         r"""
         Creates a plot of the observed track of the storm.
@@ -610,7 +609,7 @@ class Storm:
         ----------
         domain : str
             Domain for the plot. Default is "dynamic". "dynamic_tropical" is also available. Please refer to :ref:`options-domain` for available domain options.
-        plot_all : bool
+        plot_all_dots : bool
             Whether to plot dots for all observations along the track. If false, dots will be plotted every 6 hours. Default is false.
         ax : axes
             Instance of axes to plot on. If none, one will be generated. Default is none.
@@ -645,7 +644,7 @@ class Storm:
             self.plot_obj.proj = cartopy_proj
             
         #Plot storm
-        plot_ax = self.plot_obj.plot_storm(self.dict,domain,plot_all,ax=ax,return_ax=return_ax,prop=prop,map_prop=map_prop,save_path=save_path)
+        plot_ax = self.plot_obj.plot_storm(self.dict,domain,plot_all_dots,ax=ax,return_ax=return_ax,prop=prop,map_prop=map_prop,save_path=save_path)
         
         #Return axis
         if ax != None or return_ax == True: return plot_ax
@@ -1691,7 +1690,7 @@ class Storm:
 
             
     def plot_tors(self,dist_thresh=1000,Tors=None,domain="dynamic",plotPPH=False,plot_all=False,\
-                  ax=None,return_ax=False,cartopy_proj=None,prop={},map_prop={}):
+                  ax=None,return_ax=False,cartopy_proj=None,save_path=None,prop={},map_prop={}):
                 
         r"""
         Creates a plot of the storm and associated tornado tracks.
@@ -1720,6 +1719,9 @@ class Storm:
             If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
         cartopy_proj : ccrs
             Instance of a cartopy projection to use. If none, one will be generated. Default is none.
+        save_path : str
+            Relative or full path of directory to save the image in. If none, image will not be saved.
+        
         
         Other Parameters
         ----------------
@@ -1788,11 +1790,15 @@ class Storm:
         if ax != None or return_ax == True: 
             return plot_ax
         else:
-            plt.show()
+            #Save image if specified
+            if save_path != None and isinstance(save_path,str) == True:
+                plt.savefig(save_path,bbox_inches='tight')
+            else:
+                plt.show()
             plt.close()
 
 
-    def plot_TCtors_rotated(self,dist_thresh=1000,return_ax=False):
+    def plot_TCtors_rotated(self,dist_thresh=1000,return_ax=False,save_path=None):
         
         r"""
         Plot tracks of tornadoes relative to the storm motion vector of the tropical cyclone.
@@ -1803,6 +1809,8 @@ class Storm:
             Distance threshold (in kilometers) from the tropical cyclone track over which to attribute tornadoes to the TC. Default is 1000 km. Ignored if tornado data was passed into Storm from TrackDataset.
         return_ax : bool
             If True, returns the axes instance on which the plot was generated for the user to further modify. Default is False.
+        save_path : str
+            Relative or full path of directory to save the image in. If none, image will not be saved.
         
         Notes
         -----
@@ -1867,7 +1875,10 @@ class Storm:
         if return_ax == True:
             return ax
         else:
-            plt.show()
+            if save_path != None and isinstance(save_path,str) == True:
+                plt.savefig(save_path,bbox_inches='tight')
+            else:
+                plt.show()
             plt.close()
             
     def get_recon(self,deltap_thresh=8,save_path="",read_path="",mission_url_list=None,update=False):

--- a/src/tropycal/tracks/tools.py
+++ b/src/tropycal/tracks/tools.py
@@ -389,7 +389,7 @@ def filter_storms_vp(trackdata,year_min=0,year_max=9999,subset_domain=None):
     """
     
     #If no subset domain is passed, use global data
-    if subset_domain == None:
+    if subset_domain is None:
         lon_min,lon_max,lat_min,lat_max = [0,360,-90,90]
     else:
         lon_min,lon_max,lat_min,lat_max = [float(i) for i in subset_domain.split("/")]

--- a/src/tropycal/utils/__init__.py
+++ b/src/tropycal/utils/__init__.py
@@ -1,4 +1,5 @@
 r"""Collection of basic tools used by Tropycal."""
 
 from .generic_utils import *
+from .cartopy_utils import *
 from .colors import *

--- a/src/tropycal/utils/cartopy_utils.py
+++ b/src/tropycal/utils/cartopy_utils.py
@@ -1,0 +1,53 @@
+r"""Adds Tropycal functionality to Cartopy GeoAxes."""
+
+import types
+import cartopy.crs as ccrs
+
+def add_tropycal(ax):
+    
+    r"""
+    Adds Tropycal plotting capability to a matplotlib.pyplot axes instance with a Cartopy projection.
+    
+    This axes instance must have already had a Cartopy projection added (e.g., ``projection=ccrs.PlateCarree()``).
+    
+    Parameters
+    ----------
+    ax : cartopy.mpl.geoaxes.GeoAxes
+        Instance of a matplotlib axes with a Cartopy projection added.
+    
+    Returns
+    -------
+    ax
+        The same axes instance is returned, with tropycal plotting functions from `tropycal.utils.cartopy_utils` added to it as methods.
+    """
+    
+    ax.plot_storm = types.MethodType( plot_storm, ax )
+    
+    return ax
+    
+def plot_storm(self,storm,*args,**kwargs):
+    
+    r"""
+    Plot a Storm object on the axes instance.
+    
+    Parameters
+    ----------
+    storm : tropycal.tracks.Storm
+        Instance of a Storm object to be plotted.
+    
+    Notes
+    -----
+    Besides the parameters listed above, this function behaves identically to matplotlib's default `plot()` function.
+    
+    It is not necessary to pass a "transform" keyword argument, as this is already assumed to be ccrs.PlateCarree().
+    
+    This function is already appended to an axes instance if ``ax = utils.add_tropycal(ax)`` is run beforehand. This allows this method to be called simply via ``ax.plot_storm(...)`` the same way one would call ``ax.plot(...)``.
+    """
+    
+    #Filter to only tropical points if requested
+    if 'stormtype' in kwargs.keys():
+        stormtype = kwargs.pop('stormtype')
+        storm = storm.sel(stormtype=stormtype)
+    
+    #Pass arguments to ax plot method
+    self.plot(storm.lon,storm.lat,*args,**kwargs,transform=ccrs.PlateCarree())

--- a/src/tropycal/utils/generic_utils.py
+++ b/src/tropycal/utils/generic_utils.py
@@ -134,6 +134,8 @@ def get_storm_classification(wind_speed,subtropical_flag,basin):
     r"""
     Retrieve the tropical cyclone classification given its subtropical status and current basin.
     
+    These strings take the format of "Tropical Storm", "Hurricane", "Typhoon", etc.
+    
     Warning: This function currently does not differentiate between 1-minute, 3-minute and 10-minute sustained wind speeds.
     
     Parameters
@@ -241,7 +243,7 @@ def get_storm_classification(wind_speed,subtropical_flag,basin):
 def get_storm_type(wind_speed,subtropical_flag):
     
     r"""
-    Retrieve the 2-character tropical cyclone type given its subtropical status.
+    Retrieve the 2-character tropical cyclone type (e.g., "TD", "TS", "HU") given its subtropical status.
     
     Parameters
     ----------
@@ -294,7 +296,7 @@ def get_basin(lat,lon,storm_id=""):
     Returns
     -------
     str
-        String representing the current basin.
+        String representing the current basin (e.g., "north_atlantic", "east_pacific").
     """
     
     #Error check
@@ -371,7 +373,7 @@ def knots_to_mph(wind_speed):
 def accumulated_cyclone_energy(wind_speed,hours=6):
     
     r"""
-    Calculate Cccumulated Cyclone Energy (ACE) based on sustained wind speed in knots.
+    Calculate Accumulated Cyclone Energy (ACE) based on sustained wind speed in knots.
     
     Parameters
     ----------

--- a/src/tropycal/utils/generic_utils.py
+++ b/src/tropycal/utils/generic_utils.py
@@ -184,7 +184,7 @@ def get_storm_classification(wind_speed,subtropical_flag,basin):
                 return "Subtropical Storm"
             else:
                 return "Tropical Storm"
-        elif wind_speed < 120:
+        elif wind_speed < 130:
             return "Typhoon"
         else:
             return "Super Typhoon"

--- a/tests/tracks.py
+++ b/tests/tracks.py
@@ -47,49 +47,46 @@ def test_code():
             ax = ax['ax']
         
         return fig
-
-    #method2(storm.plot, ['spam'], {'ham': 'ham'})
     
     #Retrieve HURDAT2 reanalysis dataset for North Atlantic
-    hurdat_atl = tracks.TrackDataset()
-
+    basin = tracks.TrackDataset()
         
     #Assign all tornadoes to storm
-    hurdat_atl.assign_storm_tornadoes()
+    basin.assign_storm_tornadoes()
     
     #------------------------------------------------------------
     
     #Search name
-    hurdat_atl.search_name('michael')
+    basin.search_name('michael')
     
     #Test getting storm ID
-    storm_id = hurdat_atl.get_storm_id(('michael', 2018))
+    storm_id = basin.get_storm_id(('michael', 2018))
     if storm_id != 'AL142018':
         raise AssertionError("Incorrect type")
     
     #Test retrieving hurricane Michael (2018)
-    storm = hurdat_atl.get_storm(('michael', 2018))
+    storm = basin.get_storm(('michael', 2018))
     
     #Cartopy proj
     proj = ccrs.PlateCarree(central_longitude=0.0)
     
     #Make plot of storm track
-    test_plot(storm.plot, proj, True, [], {'return_ax': True}, use_figsize=(14,9))
+    test_plot(storm.plot, proj, True, [], {}, use_figsize=(14,9))
+    
+    #Make plot of storm tracks
+    test_plot(basin.plot_storms, proj, True, [['AL012018','AL012019']], {}, use_figsize=(14,9))
     
     #Get NHC discussion
     disco = storm.get_nhc_discussion(forecast=1)
     
     #Plot NHC forecast
-    test_plot(storm.plot_nhc_forecast, proj, True, [], {'forecast': 1, 'return_ax': True}, use_figsize=(14,9))
-    #ax = storm.plot_nhc_forecast(forecast=1,return_ax=True)
+    test_plot(storm.plot_nhc_forecast, proj, True, [], {'forecast': 1}, use_figsize=(14,9))
     
     #Plot storm tornadoes
-    #test_plot(storm.plot_tors, proj, [], {'return_ax': True})
-    #ax = storm.plot_tors(return_ax=True)
+    test_plot(storm.plot_tors, proj, True, [], {'return_ax': True})
     
     #Plot rotated tornadoes
-    test_plot(storm.plot_TCtors_rotated, proj, False, [], {'return_ax': True}, use_figsize=(9,9), use_dpi=150)
-    #ax = storm.plot_TCtors_rotated(return_ax=True)
+    test_plot(storm.plot_TCtors_rotated, proj, False, [], {}, use_figsize=(9,9), use_dpi=150)
     
     #Convert to datatypes
     storm.to_dict()
@@ -100,11 +97,10 @@ def test_code():
     #------------------------------------------------------------
     
     #Test retrieving season
-    season = hurdat_atl.get_season(2017)
+    season = basin.get_season(2017)
     
     #Make plot of season
-    test_plot(season.plot, proj, True, [], {'return_ax': True}, use_figsize=(14,9))
-    #ax = season.plot(return_ax=True)
+    test_plot(season.plot, proj, True, [], {}, use_figsize=(14,9))
     
     #Annual summary
     season.summary()
@@ -115,9 +111,9 @@ def test_code():
     #------------------------------------------------------------
     
     #Rank storms
-    hurdat_atl.rank_storm('ace')
+    basin.rank_storm('ace')
     
     #Gridded stats
-    test_plot(hurdat_atl.gridded_stats, proj, True, ['maximum wind'], {}, use_figsize=(14,9))
-    #hurdat_atl.gridded_stats('maximum wind',return_ax=True)
+    test_plot(basin.gridded_stats, proj, True, ['maximum wind'], {}, use_figsize=(14,9))
     
+test_code()

--- a/tests/tracks.py
+++ b/tests/tracks.py
@@ -9,6 +9,7 @@ import pytest
 
 from cartopy import crs as ccrs
 import tropycal.tracks as tracks
+import tropycal.rain as rain
 
 def assert_almost_equal(actual, desired, decimal=7):
     """Check that values are almost equal, including units.
@@ -83,7 +84,7 @@ def test_code():
     test_plot(storm.plot_nhc_forecast, proj, True, [], {'forecast': 1}, use_figsize=(14,9))
     
     #Plot storm tornadoes
-    test_plot(storm.plot_tors, proj, True, [], {'return_ax': True})
+    test_plot(storm.plot_tors, proj, True, [], {})
     
     #Plot rotated tornadoes
     test_plot(storm.plot_TCtors_rotated, proj, False, [], {}, use_figsize=(9,9), use_dpi=150)


### PR DESCRIPTION
This PR is a major step towards releasing v0.3, with many bug fixes, documentation clean-up, and new functionalities.

Bug fixes:
- fixed bug in filter_storms where lon values were only accepted from 0 to 360
- fixed bug in storm plotting options where extratropical points were a mix of solid and dash line
- removed arguments from multiple functions that were either unused or would break the code if not used in a very specific manner (the latter can be added back later after more thorough testing)
- some plotting functions returned multiple arguments when "return_ax" was set to True, resulting in an inconsistent
behavior across plotting functions. This is now consistent across all plotting functions such that when return_ax=True,
only the plotting axes is returned, except for "gridded_stats" where if both the axes and data are set to be returned,
a dictionary containing both is returned.

Non-backwards compatible changes:
- all plotting functions that had the argument "plot_all" have been renamed to "plot_all_dots" to make the name more intuitive.
If true, then all location dots of a tropical cyclone's observed location are plotted even if they fall outside of
the standard 0/6/12/18z 6-hour increments.
- all plotting functions now have a "save_path" argument, to allow for saving the image generated. Some of these were previously a mix of only specifying the directory path or including the file name as part of the path; as of v0.3, this now expects to receive a relative or full path that *includes* the file name, making this consistent across all functions. This can be revised in later versions - one option would be to add a "save_name" argument separate from "save_path", with a default name generated if one is not passed.

New features:
- A new Rain module has been added, retrieving data from the Weather Prediction Center (WPC)'s tropical cyclone rainfall database. This includes method to convert the unstructured rain data into a lat/lon grid, as well as plotting either the grid or individual dots.
- A new cartopy utility functionality was added, where a ``plot_storm()`` method can be added to a Cartopy geoAxes instance, allowing for quick plotting of Storm objects.

Additional notes:
- Documentation for classes is now split by method instead of listing all of a class's method in the same page, making the documentation easier to navigate through instead of a single massive cluttered page.