### PR TITLE
Fix bugs

### DIFF
--- a/src/tropycal/constants.py
+++ b/src/tropycal/constants.py
@@ -1,0 +1,13 @@
+r"""A collection of relevant constants used throughout Tropycal scripts."""
+
+#Tropical or subtropical storm types (including depressions)
+TROPICAL_STORM_TYPES = frozenset(['SD','SS','TD','TS','HU'])
+
+#Tropical or subtropical storm types (excluding depressions)
+NAMED_TROPICAL_STORM_TYPES = frozenset(['SS','TS','HU'])
+
+#Tropical only storm types
+TROPICAL_ONLY_STORM_TYPES = frozenset(['TD','TS','HU'])
+
+#Tropical only storm types
+SUBTROPICAL_ONLY_STORM_TYPES = frozenset(['SD','SS'])

--- a/src/tropycal/constants.py
+++ b/src/tropycal/constants.py
@@ -11,3 +11,6 @@ TROPICAL_ONLY_STORM_TYPES = frozenset(['TD','TS','HU'])
 
 #Tropical only storm types
 SUBTROPICAL_ONLY_STORM_TYPES = frozenset(['SD','SS'])
+
+#Standard 00/06/12/18 UTC hours
+STANDARD_HOURS = frozenset(['0000','0600','1200','1800'])

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -264,6 +264,10 @@ class Realtime():
                 btk_mslp = int(line[9])
                 btk_type = line[10]
                 name = line[27]
+                
+                #Get last tropical date
+                if btk_type in ['SD','SS','TD','TS','HU']:
+                    last_tropical_date = date + timedelta(hours=0)
 
                 #Replace with NaNs
                 if btk_wind > 250 or btk_wind < 10: btk_wind = np.nan
@@ -301,6 +305,16 @@ class Realtime():
 
             #Add storm name
             self.data[stormid]['name'] = name
+            
+            #Check if storm is still tropical, if not an invest.
+            #Re-designate as an invest if has not been a TC for over 18 hours.
+            try:
+                current_date = dt.utcnow()
+                date_diff = (current_date - last_tropical_date).total_seconds() / 3600
+                if date_diff > 18:
+                    self.data[stormid]['invest'] = True
+            except:
+                pass
         
         
     def __read_btk_jtwc(self,source):

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -147,7 +147,10 @@ class Realtime():
             
             #Get time difference
             hours_diff = (current_date - last_date).total_seconds() / 3600.0
-            if hours_diff >= 18.0: del self.data[key]
+            if self.data[key]['invest']:
+                if hours_diff >= 9.0: del self.data[key]
+            else:
+                if hours_diff >= 18.0: del self.data[key]
         
         #For each storm remaining, create a Storm object
         if len(self.data) > 0:

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -433,7 +433,7 @@ class Realtime():
                     btk_type = get_storm_type(btk_wind,False)
                 else:
                     btk_type = line[10]
-                    if btk_type == "TY": btk_type = "HU"
+                    if btk_type == "TY" or btk_type == "ST": btk_type = "HU"
                 name = line[27]
 
                 #Replace with NaNs

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -309,13 +309,11 @@ class Realtime():
             
             #Check if storm is still tropical, if not an invest.
             #Re-designate as an invest if has not been a TC for over 18 hours.
-            try:
+            if True in [type in self.data[stormid]['type'] for type in constants.TROPICAL_STORM_TYPES]:
                 current_date = dt.utcnow()
                 date_diff = (current_date - last_tropical_date).total_seconds() / 3600
                 if date_diff > 18:
                     self.data[stormid]['invest'] = True
-            except:
-                pass
         
         
     def __read_btk_jtwc(self,source):

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -147,10 +147,8 @@ class Realtime():
             
             #Get time difference
             hours_diff = (current_date - last_date).total_seconds() / 3600.0
-            if self.data[key]['invest']:
-                if hours_diff >= 9.0: del self.data[key]
-            else:
-                if hours_diff >= 18.0: del self.data[key]
+            if hours_diff >= 18.0 or (self.data[key]['invest'] and hours_diff >= 9.0):
+                del self.data[key]
         
         #For each storm remaining, create a Storm object
         if len(self.data) > 0:
@@ -245,7 +243,7 @@ class Realtime():
 
                 #Get date of obs
                 date = dt.strptime(line[2],'%Y%m%d%H')
-                if date.hour not in [0,6,12,18]: continue
+                if date.strftime('%H%M') not in constants.STANDARD_HOURS: continue
 
                 #Ensure obs aren't being repeated
                 if date in self.data[stormid]['date']: continue
@@ -403,7 +401,7 @@ class Realtime():
 
                 #Get date of obs
                 date = dt.strptime(line[2],'%Y%m%d%H')
-                if date.hour not in [0,6,12,18]: continue
+                if date.strftime('%H%M') not in constants.STANDARD_HOURS: continue
 
                 #Ensure obs aren't being repeated
                 if date in self.data[stormid]['date']: continue

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -17,10 +17,10 @@ except:
     warn_message = "Warning: Cartopy is not installed in your python environment. Plotting functions will not work."
     warnings.warn(warn_message)
 
+#Internal imports
 from .storm import RealtimeStorm
-
-#Import tools
 from ..utils import *
+from .. import constants
 
 class Realtime():
     
@@ -266,7 +266,7 @@ class Realtime():
                 name = line[27]
                 
                 #Get last tropical date
-                if btk_type in ['SD','SS','TD','TS','HU']:
+                if btk_type in constants.TROPICAL_STORM_TYPES:
                     last_tropical_date = date + timedelta(hours=0)
 
                 #Replace with NaNs
@@ -300,7 +300,7 @@ class Realtime():
                 #Calculate ACE & append to storm total
                 if np.isnan(btk_wind) == False:
                     ace = (10**-4) * (btk_wind**2)
-                    if btk_type in ['SS','TS','HU']:
+                    if btk_type in constants.NAMED_TROPICAL_STORM_TYPES:
                         self.data[stormid]['ace'] += np.round(ace,4)
 
             #Add storm name
@@ -458,7 +458,7 @@ class Realtime():
                 #Calculate ACE & append to storm total
                 if np.isnan(btk_wind) == False:
                     ace = (10**-4) * (btk_wind**2)
-                    if btk_type in ['SS','TS','HU']:
+                    if btk_type in constants.NAMED_TROPICAL_STORM_TYPES:
                         self.data[stormid]['ace'] += np.round(ace,4)
 
             #Add storm name

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -13,6 +13,7 @@ import requests
 from ..tracks import *
 from ..tracks.tools import *
 from ..utils import *
+from .. import constants
 
 try:
     import zipfile
@@ -421,7 +422,7 @@ class RealtimeStorm(Storm):
         ace = 0.0
         for i in range(len(self.date)):
             if self.date[i] >= forecasts['init']: continue
-            if self.type[i] not in ['TS','SS','HU']: continue
+            if self.type[i] not in constants.NAMED_TROPICAL_STORM_TYPES: continue
             ace += accumulated_cyclone_energy(self.vmax[i],hours=6)
         
         #Add initial forecast hour ACE
@@ -446,14 +447,14 @@ class RealtimeStorm(Storm):
                     break
                 use_i = int(i + 0.0)
             i_type = forecasts['type'][use_i]
-            if i_type in ['TD','TS','SD','SS','HU','TY']: i_type = get_storm_type(i_vmax,False)
+            if i_type in constants.TROPICAL_STORM_TYPES: i_type = get_storm_type(i_vmax,False)
             interp_type.append(i_type)
         
         #Add forecast ACE
         for i,(i_fhr,i_vmax,i_type) in enumerate(zip(interp_fhr[1:],interp_vmax[1:],interp_type[1:])):
             
             #Add ACE if storm is a TC
-            if i_type in ['TS','SS','HU','TY']:
+            if i_type in constants.NAMED_TROPICAL_STORM_TYPES:
                 ace += accumulated_cyclone_energy(i_vmax,hours=6)
             
             #Add ACE to array
@@ -700,11 +701,11 @@ class RealtimeStorm(Storm):
             current_advisory['time_utc'] = self.date[-1]
 
             #Get storm type
-            subtrop_flag = True if self.type[-1] in ['SS','SD'] else False
+            subtrop_flag = True if self.type[-1] in constants.SUBTROPICAL_ONLY_STORM_TYPES else False
             current_advisory['type'] = get_storm_classification(self.vmax[-1],subtrop_flag,self.basin)
             
             #Check for non-tropical storm types
-            if self.type[-1] not in ['SD','SS','TD','TS','HU']:
+            if self.type[-1] not in constants.TROPICAL_STORM_TYPES:
                 if 'SD' not in self.type and 'SS' not in self.type and 'TD' not in self.type and 'TS' not in self.type and 'HU' not in self.type:
                     if self.invest:
                         current_advisory['type'] = 'Invest'

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -702,6 +702,16 @@ class RealtimeStorm(Storm):
             #Get storm type
             subtrop_flag = True if self.type[-1] in ['SS','SD'] else False
             current_advisory['type'] = get_storm_classification(self.vmax[-1],subtrop_flag,self.basin)
+            
+            #Check for non-tropical storm types
+            if self.type[-1] not in ['SD','SS','TD','TS','HU']:
+                if 'SD' not in self.type and 'SS' not in self.type and 'TD' not in self.type and 'TS' not in self.type and 'HU' not in self.type:
+                    if self.invest:
+                        current_advisory['type'] = 'Invest'
+                    else:
+                        current_advisory['type'] = 'Potential Tropical Cyclone'
+                else:
+                    current_advisory['type'] = 'Post-Tropical Cyclone'
 
             #Get storm name
             current_advisory['name'] = self.name.title()

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -61,7 +61,7 @@ class RealtimeStorm(Storm):
         #Format keys for summary
         type_array = np.array(self.dict['type'])
         idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))[0]
-        if self.invest: idx = np.array([True for i in type_array])
+        if self.invest and len(idx) == 0: idx = np.array([True for i in type_array])
         if len(idx) == 0:
             start_date = 'N/A'
             end_date = 'N/A'

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -701,7 +701,7 @@ class RealtimeStorm(Storm):
             current_advisory['time_utc'] = self.date[-1]
 
             #Get storm type
-            subtrop_flag = True if self.type[-1] in constants.SUBTROPICAL_ONLY_STORM_TYPES else False
+            subtrop_flag = self.type[-1] in constants.SUBTROPICAL_ONLY_STORM_TYPES
             current_advisory['type'] = get_storm_classification(self.vmax[-1],subtrop_flag,self.basin)
             
             #Check for non-tropical storm types

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -706,7 +706,7 @@ class RealtimeStorm(Storm):
             
             #Check for non-tropical storm types
             if self.type[-1] not in constants.TROPICAL_STORM_TYPES:
-                if 'SD' not in self.type and 'SS' not in self.type and 'TD' not in self.type and 'TS' not in self.type and 'HU' not in self.type:
+                if all(type not in self.type for type in constants.TROPICAL_STORM_TYPES):
                     if self.invest:
                         current_advisory['type'] = 'Invest'
                     else:

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -330,7 +330,7 @@ class TrackDataset:
                 if mslp < 800: mslp = np.nan
                     
                 #Handle off-hour obs
-                if hhmm in ['0000','0600','1200','1800']:
+                if hhmm in constants.STANDARD_HOURS:
                     self.data[current_id]['extra_obs'].append(0)
                 else:
                     self.data[current_id]['extra_obs'].append(1)
@@ -363,7 +363,7 @@ class TrackDataset:
                 #Calculate ACE & append to storm total
                 if np.isnan(vmax) == False:
                     ace = (10**-4) * (vmax**2)
-                    if hhmm in ['0000','0600','1200','1800'] and storm_type in constants.NAMED_TROPICAL_STORM_TYPES:
+                    if hhmm in constants.STANDARD_HOURS and storm_type in constants.NAMED_TROPICAL_STORM_TYPES:
                         self.data[current_id]['ace'] += np.round(ace,4)
         
         #Account for operationally unnamed storms
@@ -506,7 +506,8 @@ class TrackDataset:
 
                 #Get date of obs
                 date = dt.strptime(line[2],'%Y%m%d%H')
-                if date.hour not in [0,6,12,18]: continue
+                date_hhmm = date.strftime('%H%M')
+                if date_hhmm not in constants.STANDARD_HOURS: continue
 
                 #Ensure obs aren't being repeated
                 if date in self.data[stormid]['date']: continue
@@ -626,11 +627,7 @@ class TrackDataset:
         
         for line in content[2:]:
             
-            #LANDFALL	IFLAG	USA_AGENCY	USA_ATCF_ID	USA_LAT	USA_LON	USA_RECORD	USA_STATUS	USA_WIND	USA_PRES
-
-
             if len(line) < 150: continue
-            #sid, year, adv_number, basin, subbasin, name, time, wmo_type, wmo_lat, wmo_lon, wmo_vmax, wmo_mslp, agency, track_type, dist_land = line[:15]
             
             ibtracs_id, year, adv_number, basin, subbasin, name, time, wmo_type, wmo_lat, wmo_lon, wmo_vmax, wmo_mslp, agency, track_type, dist_land, dist_landfall, iflag, usa_agency, sid, lat, lon, special, stype, vmax, mslp = line[:25]
             
@@ -715,7 +712,7 @@ class TrackDataset:
                     neumann[ibtracs_id]['mslp'].append(neumann_mslp)
                     
                     hhmm = neumann_date.strftime('%H%M')
-                    if hhmm in ['0000','0600','1200','1800']:
+                    if hhmm in constants.STANDARD_HOURS:
                         neumann[ibtracs_id]['extra_obs'].append(0)
                     else:
                         neumann[ibtracs_id]['extra_obs'].append(1)
@@ -730,7 +727,7 @@ class TrackDataset:
                     #Calculate ACE & append to storm total
                     if np.isnan(neumann_vmax) == False:
                         ace = (10**-4) * (neumann_vmax**2)
-                        if hhmm in ['0000','0600','1200','1800'] and neumann_type in constants.NAMED_TROPICAL_STORM_TYPES:
+                        if hhmm in constants.STANDARD_HOURS and neumann_type in constants.NAMED_TROPICAL_STORM_TYPES:
                             neumann[ibtracs_id]['ace'] += np.round(ace,4)
                         
             #Skip missing entries
@@ -825,7 +822,7 @@ class TrackDataset:
                 self.data[ibtracs_id]['mslp'].append(wmo_mslp)
 
                 hhmm = date.strftime('%H%M')
-                if hhmm in ['0000','0600','1200','1800']:
+                if hhmm in constants.STANDARD_HOURS:
                     self.data[ibtracs_id]['extra_obs'].append(0)
                 else:
                     self.data[ibtracs_id]['extra_obs'].append(1)
@@ -833,7 +830,7 @@ class TrackDataset:
                 #Calculate ACE & append to storm total
                 if np.isnan(jtwc_vmax) == False:
                     ace = (10**-4) * (jtwc_vmax**2)
-                    if hhmm in ['0000','0600','1200','1800'] and stype in constants.NAMED_TROPICAL_STORM_TYPES:
+                    if hhmm in constants.STANDARD_HOURS and stype in constants.NAMED_TROPICAL_STORM_TYPES:
                         self.data[ibtracs_id]['ace'] += np.round(ace,4)
                 
             #Handle non-WMO mode
@@ -914,7 +911,7 @@ class TrackDataset:
                 self.data[sid]['wmo_basin'].append(wmo_basin)
 
                 hhmm = date.strftime('%H%M')
-                if hhmm in ['0000','0600','1200','1800']:
+                if hhmm in constants.STANDARD_HOURS:
                     self.data[sid]['extra_obs'].append(0)
                 else:
                     self.data[sid]['extra_obs'].append(1)
@@ -922,7 +919,7 @@ class TrackDataset:
                 #Calculate ACE & append to storm total
                 if np.isnan(vmax) == False:
                     ace = (10**-4) * (vmax**2)
-                    if hhmm in ['0000','0600','1200','1800'] and stype in constants.NAMED_TROPICAL_STORM_TYPES:
+                    if hhmm in constants.STANDARD_HOURS and stype in constants.NAMED_TROPICAL_STORM_TYPES:
                         self.data[sid]['ace'] += np.round(ace,4)
                     
         #Remove empty entries

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -404,7 +404,7 @@ class TrackDataset:
                 if storm_id in increment_but_pass: current_year_id += 1
                 pass
             elif storm_id[0:2] == 'CP':
-                pass
+                self.data[key]['operational_id'] = f"{storm_id[0:2]}{num_to_str2(current_year_id)}{storm_year}"
             else:
                 #Skip potential TCs
                 if f"{storm_id[0:2]}{num_to_str2(current_year_id)}{storm_year}" in potential_tcs:

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -3154,3 +3154,159 @@ class TrackDataset:
             return {'ax':ax,'df':stormTors}
         else:
             return ax
+
+    
+    def to_dataframe(self):
+
+        r"""
+        Retrieve a Pandas DataFrame for all seasons within TrackDataset.
+        
+        Returns
+        -------
+        pandas.DataFrame
+            Returns a Pandas DataFrame containing requested data.
+        """
+
+        #Get start and end seasons in this TrackDataset object
+        start_season = self.data[self.keys[0]]['year']
+        end_season = self.data[self.keys[-1]]['year']
+
+        #Create empty dict to be used for making pandas DataFrame object
+        ds = {'season':[],'all_storms':[],'named_storms':[],'hurricanes':[],'major_hurricanes':[],'ace':[],'start_time':[],'end_time':[]}
+
+        #Iterate over all seasons in the TrackDataset object
+        for season in range(start_season,end_season+1):
+
+            #Get season summary
+            season_summary = self.get_season(season).summary()
+
+            #Add information to dict
+            ds['season'].append(season)
+            ds['all_storms'].append(season_summary['season_storms'])
+            ds['named_storms'].append(season_summary['season_named'])
+            ds['hurricanes'].append(season_summary['season_hurricane'])
+            ds['major_hurricanes'].append(season_summary['season_major'])
+            ds['ace'].append(season_summary['season_ace'])
+            ds['start_time'].append(season_summary['season_start'])
+            ds['end_time'].append(season_summary['season_end'])
+
+        #Convert entire dict to a DataFrame
+        ds = pd.DataFrame(ds)
+
+        #Return dataset
+        return ds.set_index('season')
+
+    def climatology(self,start_season=1991,end_season=2020):
+
+        r"""
+        Create a climatology for this dataset given start and end seasons. If none passed, defaults to 1991-2020.
+        
+        Parameters
+        ----------
+        start_season : int, optional
+            First season for the climatology range.
+        end_season : int, optional
+            Ending season for the climatology range.
+        
+        Returns
+        -------
+        dict
+            Dictionary containing the climatology for this dataset.
+        """
+
+        #Error check
+        if start_season >= end_season:
+            raise ValueError("start_season cannot be greater than end_season.")
+        if isinstance(start_season,int) == False or isinstance(end_season,int) == False:
+            raise TypeError("start_season and end_season must be of type int.")
+        if (end_season - start_season) < 5:
+            raise ValueError("A minimum of 5 seasons is required for constructing a climatology.")
+
+        #Retrieve data for all seasons in this dataset
+        full_climo = self.to_dataframe()
+
+        #Subset rows by year range
+        subset_climo = full_climo.loc[start_season:end_season+1]
+
+        #Convert dates to julian days
+        julian_start = [convert_to_julian(pd.to_datetime(i)) for i in subset_climo['start_time'].values]
+        julian_end = [convert_to_julian(pd.to_datetime(i)) for i in subset_climo['end_time'].values]
+        julian_end = [i+365 if i < 100 else i for i in julian_end]
+        subset_climo = subset_climo.drop(columns=['start_time','end_time'])
+        subset_climo['start_time'] = julian_start
+        subset_climo['end_time'] = julian_end
+
+        #Calculate means
+        subset_climo_means = (subset_climo.mean(axis=0)).round(1)
+
+        #Compile averages
+        climatology = {}
+        for key in ['all_storms','named_storms','hurricanes','major_hurricanes','ace']:
+            climatology[key] = subset_climo_means[key]
+        for key in ['start_time','end_time']:
+            climatology[key] = dt(dt.now().year-1,12,31)+timedelta(hours=24*subset_climo_means[key])
+
+        #Return dict
+        return climatology
+
+    def season_composite(self,seasons,climo_bounds=None):
+
+        r"""
+        Create composite statistics for a list of seasons.
+        
+        Parameters
+        ----------
+        seasons : list
+            List of seasons to create a composite of. For Southern Hemisphere, season is the start of the two-year period.
+        climo_bounds : list or tuple
+            List or tuple of start and end years of climatology bounds. If none, defaults to (1991,2020).
+        
+        Returns
+        -------
+        dict
+            Dictionary containing the composite of the requested seasons.
+        """
+
+        #Error check
+        if isinstance(seasons,list) == False:
+            raise TypeError("'seasons' must be of type list.")
+
+        #Create climo bounds
+        if climo_bounds is None:
+            climo_bounds = (1991,2020)
+
+        #Get Season object for the composite
+        summary = self.get_season(seasons).summary()
+
+        #Get basin climatology
+        climatology = self.climatology(climo_bounds[0],climo_bounds[1])
+        full_climo = self.to_dataframe()
+        subset_climo = full_climo.loc[climo_bounds[0]:climo_bounds[1]+1]
+
+        #Create composite dictionary
+        map_keys = {'all_storms':'season_storms',
+                    'named_storms':'season_named',
+                    'hurricanes':'season_hurricane',
+                    'major_hurricanes':'season_major',
+                    'ace':'season_ace',
+                   }
+        composite = {}
+        for key in map_keys.keys():
+
+            #Get list from seasons
+            season_list = summary[map_keys.get(key)]
+
+            #Get climatology
+            season_climo = climatology[key]
+
+            #Get individual years in climatology
+            season_fullclimo = subset_climo[key].values
+
+            #Create dictionary of relevant calculations for this entry
+            composite[key] = {'list':season_list,
+                              'average':np.round(np.average(season_list),1),
+                              'composite_anomaly':np.round(np.average(season_list)-season_climo,1),
+                              'percentile_ranks':[np.round(stats.percentileofscore(season_fullclimo,i),1) for i in season_list],
+                             }
+
+        return composite

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import re
 import scipy.interpolate as interp
+import scipy.stats as stats
 import urllib
 import warnings
 from datetime import datetime as dt,timedelta
@@ -3196,17 +3197,15 @@ class TrackDataset:
         #Return dataset
         return ds.set_index('season')
 
-    def climatology(self,start_season=1991,end_season=2020):
+    def climatology(self,year_range=(1991,2020)):
 
         r"""
         Create a climatology for this dataset given start and end seasons. If none passed, defaults to 1991-2020.
         
         Parameters
         ----------
-        start_season : int, optional
-            First season for the climatology range.
-        end_season : int, optional
-            Ending season for the climatology range.
+        year_range : list or tuple, optional
+            Start and end year for the climatology range. Default is (1991,2020).
         
         Returns
         -------
@@ -3215,6 +3214,11 @@ class TrackDataset:
         """
 
         #Error check
+        if isinstance(year_range,(list,tuple)) == False:
+            raise TypeError("year_range must be of type list or tuple.")
+        if len(year_range) != 2:
+            raise TypeError("year_range must have two elements, start and end year.")
+        start_season,end_season = year_range
         if start_season >= end_season:
             raise ValueError("start_season cannot be greater than end_season.")
         if isinstance(start_season,int) == False or isinstance(end_season,int) == False:
@@ -3279,7 +3283,7 @@ class TrackDataset:
         summary = self.get_season(seasons).summary()
 
         #Get basin climatology
-        climatology = self.climatology(climo_bounds[0],climo_bounds[1])
+        climatology = self.climatology(climo_bounds)
         full_climo = self.to_dataframe()
         subset_climo = full_climo.loc[climo_bounds[0]:climo_bounds[1]+1]
 

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -20,6 +20,7 @@ from ..tornado import *
 #Import tools
 from .tools import *
 from ..utils import *
+from .. import constants
 
 #Import matplotlib
 try:
@@ -362,7 +363,7 @@ class TrackDataset:
                 #Calculate ACE & append to storm total
                 if np.isnan(vmax) == False:
                     ace = (10**-4) * (vmax**2)
-                    if hhmm in ['0000','0600','1200','1800'] and storm_type in ['SS','TS','HU']:
+                    if hhmm in ['0000','0600','1200','1800'] and storm_type in constants.NAMED_TROPICAL_STORM_TYPES:
                         self.data[current_id]['ace'] += np.round(ace,4)
         
         #Account for operationally unnamed storms
@@ -559,7 +560,7 @@ class TrackDataset:
                 #Calculate ACE & append to storm total
                 if np.isnan(btk_wind) == False:
                     ace = (10**-4) * (btk_wind**2)
-                    if btk_type in ['SS','TS','HU']:
+                    if btk_type in constants.NAMED_TROPICAL_STORM_TYPES:
                         self.data[stormid]['ace'] += np.round(ace,4)
 
             #Add storm name
@@ -729,7 +730,7 @@ class TrackDataset:
                     #Calculate ACE & append to storm total
                     if np.isnan(neumann_vmax) == False:
                         ace = (10**-4) * (neumann_vmax**2)
-                        if hhmm in ['0000','0600','1200','1800'] and neumann_type in ['SS','TS','HU']:
+                        if hhmm in ['0000','0600','1200','1800'] and neumann_type in constants.NAMED_TROPICAL_STORM_TYPES:
                             neumann[ibtracs_id]['ace'] += np.round(ace,4)
                         
             #Skip missing entries
@@ -832,7 +833,7 @@ class TrackDataset:
                 #Calculate ACE & append to storm total
                 if np.isnan(jtwc_vmax) == False:
                     ace = (10**-4) * (jtwc_vmax**2)
-                    if hhmm in ['0000','0600','1200','1800'] and stype in ['SS','TS','HU']:
+                    if hhmm in ['0000','0600','1200','1800'] and stype in constants.NAMED_TROPICAL_STORM_TYPES:
                         self.data[ibtracs_id]['ace'] += np.round(ace,4)
                 
             #Handle non-WMO mode
@@ -921,7 +922,7 @@ class TrackDataset:
                 #Calculate ACE & append to storm total
                 if np.isnan(vmax) == False:
                     ace = (10**-4) * (vmax**2)
-                    if hhmm in ['0000','0600','1200','1800'] and stype in ['SS','TS','HU']:
+                    if hhmm in ['0000','0600','1200','1800'] and stype in constants.NAMED_TROPICAL_STORM_TYPES:
                         self.data[sid]['ace'] += np.round(ace,4)
                     
         #Remove empty entries
@@ -2060,16 +2061,16 @@ class TrackDataset:
             T = np.array(storm_data['type'])
 
             def get_color(itype):
-                if itype in ['SD','SS','TD','TS','HU']:
+                if itype in constants.TROPICAL_STORM_TYPES:
                     return ['#00EE00','palegreen'] #lime
                 else:
                     return ['#00A600','#3BD73B']
                 
             def getMarker(itype):
                 mtype = '^'
-                if itype in ['SD','SS']:
+                if itype in constants.SUBTROPICAL_ONLY_STORM_TYPES:
                     mtype = 's'
-                elif itype in ['TD','TS','HU']:
+                elif itype in constants.TROPICAL_ONLY_STORM_TYPES:
                     mtype = 'o'
                 return mtype
             
@@ -2077,15 +2078,15 @@ class TrackDataset:
             tr_label = False
             for i,(iv,ip,it) in enumerate(zip(V[:-1],P[:-1],T[:-1])):
                 check = False
-                if it in ['SD','SS','TD','TS','HU'] and tr_label == True: check = True
-                if not it in ['SD','SS','TD','TS','HU'] and xt_label == True: check = True
+                if it in constants.TROPICAL_STORM_TYPES and tr_label == True: check = True
+                if not it in constants.TROPICAL_STORM_TYPES and xt_label == True: check = True
                 if check:
                     plt.scatter(iv, ip, marker='o',s=80,color=get_color(it)[0],edgecolor='k',zorder=9)
                 else:
-                    if it in ['SD','SS','TD','TS','HU'] and tr_label == False:
+                    if it in constants.TROPICAL_STORM_TYPES and tr_label == False:
                         tr_label = True
                         label_content = f"{storm_data['name'].title()} {storm_data['year']} (Tropical)"
-                    if it not in ['SD','SS','TD','TS','HU'] and xt_label == False:
+                    if it not in constants.TROPICAL_STORM_TYPES and xt_label == False:
                         xt_label = True
                         label_content = f"{storm_data['name'].title()} {storm_data['year']} (Non-Tropical)"
                     plt.scatter(iv, ip, marker='o',s=80,color=get_color(it)[0],edgecolor='k',label=label_content,zorder=9)
@@ -2549,7 +2550,7 @@ class TrackDataset:
             for i in range(len(istorm['date'])):
                 
                 #Filter to only tropical cyclones, and filter by dates & coordiates
-                if istorm['type'][i] in ['TD','SD','TS','SS','HU','TY'] \
+                if istorm['type'][i] in constants.TROPICAL_STORM_TYPES \
                 and lat_min<=istorm['lat'][i]<=lat_max and lon_min<=istorm['lon'][i]%360<=lon_max \
                 and year_min<=istorm['date'][i].year<=year_max \
                 and date_range_test(istorm['date'][i],date_min,date_max):

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -256,7 +256,7 @@ class TrackPlot(Plot):
         #Add left title
         type_array = np.array(storm_data['type'])
         idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))
-        if invest_bool == False or len(idx) > 0:
+        if invest_bool == False or len(idx[0]) > 0:
             tropical_vmax = np.array(storm_data['vmax'])[idx]
             
             #Coerce to include non-TC points if storm hasn't been designated yet

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -254,8 +254,8 @@ class TrackPlot(Plot):
         
         #Add left title
         type_array = np.array(storm_data['type'])
-        if invest_bool == False:
-            idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))
+        idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))
+        if invest_bool == False or len(idx) > 0:
             tropical_vmax = np.array(storm_data['vmax'])[idx]
             
             #Coerce to include non-TC points if storm hasn't been designated yet

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -192,7 +192,7 @@ class TrackPlot(Plot):
                 
                 #Skip if plot_all_dots == False and not in 0,6,12,18z
                 if plot_all_dots == False:
-                    if i_date.strftime('%H%M') not in ['0000','0600','1200','1800']: continue
+                    if i_date.strftime('%H%M') not in constants.STANDARD_HOURS: continue
 
                 #Determine fill color, with SSHWS scale used as default
                 if prop['fillcolor'] == 'category':
@@ -593,7 +593,7 @@ class TrackPlot(Plot):
 
                     #Skip if plot_all_dots == False and not in 0,6,12,18z
                     if plot_all_dots == False:
-                        if i_date.strftime('%H%M') not in ['0000','0600','1200','1800']: continue
+                        if i_date.strftime('%H%M') not in constants.STANDARD_HOURS: continue
 
                     #Determine fill color, with SSHWS scale used as default
                     if prop['fillcolor'] == 'category':
@@ -1101,7 +1101,7 @@ None,prop={},map_prop={}):
         if all_nan(first_fcst_wind) == True:
             storm_type = 'Unknown'
         else:
-            subtrop = True if first_fcst_type in constants.SUBTROPICAL_ONLY_STORM_TYPES else False
+            subtrop = first_fcst_type in constants.SUBTROPICAL_ONLY_STORM_TYPES
             cur_wind = first_fcst_wind + 0
             storm_type = get_storm_classification(np.nan_to_num(cur_wind),subtrop,'north_atlantic')
         
@@ -1125,7 +1125,7 @@ None,prop={},map_prop={}):
                 for i,(iwnd,ityp) in enumerate(zip(vmax,styp)):
                     if ityp in constants.TROPICAL_STORM_TYPES:
                         storm_tropical = True
-                        subtrop = True if ityp in constants.SUBTROPICAL_ONLY_STORM_TYPES else False
+                        subtrop = ityp in constants.SUBTROPICAL_ONLY_STORM_TYPES
                         storm_type = get_storm_classification(np.nan_to_num(iwnd),subtrop,'north_atlantic')
                         if np.isnan(iwnd) == True: storm_type = 'Unknown'
                     else:

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -162,7 +162,7 @@ class TrackPlot(Plot):
 
             #For tropical/subtropical types, color-code if requested
             if i > 0:
-                if i_type in ['SD','TD','SS','TS','HU']:
+                if i_type in ['SD','TD','SS','TS','HU'] and storm_data['type'][i-1] in ['SD','TD','SS','TS','HU']:
 
                     #Plot underlying black and overlying colored line
                     self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],'-',
@@ -563,7 +563,7 @@ class TrackPlot(Plot):
 
                 #For tropical/subtropical types, color-code if requested
                 if i > 0:
-                    if i_type in ['SD','TD','SS','TS','HU']:
+                    if i_type in ['SD','TD','SS','TS','HU'] and storm_data['type'][i-1] in ['SD','TD','SS','TS','HU']:
 
                         #Plot underlying black and overlying colored line
                         self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],'-',
@@ -1583,7 +1583,7 @@ None,prop={},map_prop={}):
 
                 #For tropical/subtropical types, color-code if requested
                 if i > 0:
-                    if i_type in ['SD','TD','SS','TS','HU']:
+                    if i_type in ['SD','TD','SS','TS','HU'] and storm['type'][i-1] in ['SD','TD','SS','TS','HU']:
 
                         #Plot underlying black and overlying colored line
                         self.ax.plot([lons[i-1],lons[i]],[storm['lat'][i-1],storm['lat'][i]],'-',

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -14,6 +14,7 @@ from ..plot import Plot
 #Import tools
 from .tools import *
 from ..utils import *
+from .. import constants
 
 try:
     import cartopy.feature as cfeature
@@ -162,7 +163,7 @@ class TrackPlot(Plot):
 
             #For tropical/subtropical types, color-code if requested
             if i > 0:
-                if i_type in ['SD','TD','SS','TS','HU'] and storm_data['type'][i-1] in ['SD','TD','SS','TS','HU']:
+                if i_type in constants.TROPICAL_STORM_TYPES and storm_data['type'][i-1] in constants.TROPICAL_STORM_TYPES:
 
                     #Plot underlying black and overlying colored line
                     self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],'-',
@@ -214,9 +215,9 @@ class TrackPlot(Plot):
 
                 #Determine dot type
                 marker_type = '^'
-                if i_type in ['SD','SS']:
+                if i_type in constants.SUBTROPICAL_ONLY_STORM_TYPES:
                     marker_type = 's'
-                elif i_type in ['TD','TS','HU']:
+                elif i_type in constants.TROPICAL_ONLY_STORM_TYPES:
                     marker_type = 'o'
 
                 #Plot marker
@@ -563,7 +564,7 @@ class TrackPlot(Plot):
 
                 #For tropical/subtropical types, color-code if requested
                 if i > 0:
-                    if i_type in ['SD','TD','SS','TS','HU'] and storm_data['type'][i-1] in ['SD','TD','SS','TS','HU']:
+                    if i_type in constants.TROPICAL_STORM_TYPES and storm_data['type'][i-1] in constants.TROPICAL_STORM_TYPES:
 
                         #Plot underlying black and overlying colored line
                         self.ax.plot([lons[i-1],lons[i]],[storm_data['lat'][i-1],storm_data['lat'][i]],'-',
@@ -615,9 +616,9 @@ class TrackPlot(Plot):
 
                     #Determine dot type
                     marker_type = '^'
-                    if i_type in ['SD','SS']:
+                    if i_type in constants.SUBTROPICAL_ONLY_STORM_TYPES:
                         marker_type = 's'
-                    elif i_type in ['TD','TS','HU']:
+                    elif i_type in constants.TROPICAL_ONLY_STORM_TYPES:
                         marker_type = 'o'
 
                     #Plot marker
@@ -918,7 +919,7 @@ None,prop={},map_prop={}):
                     type6 = np.array(styp)
                     for i in (np.arange(len(lats[1:]))+1):
                         ltype = 'solid'
-                        if type6[i] not in ['SS','SD','TD','TS','HU']: ltype = 'dotted'
+                        if type6[i] not in constants.TROPICAL_STORM_TYPES: ltype = 'dotted'
                         self.ax.plot([lons[i-1],lons[i]],[lats[i-1],lats[i]],
                                       '-',color=get_colors_sshws(np.nan_to_num(vmax[i])),linewidth=prop['linewidth'],linestyle=ltype,
                                       transform=ccrs.PlateCarree(),
@@ -937,9 +938,9 @@ None,prop={},map_prop={}):
                     type6 = np.array(styp)#[time_idx]
                     for i,(ilon,ilat,iwnd,itype) in enumerate(zip(lon6,lat6,vmax6,type6)):
                         mtype = '^'
-                        if itype in ['SD','SS']:
+                        if itype in constants.SUBTROPICAL_ONLY_STORM_TYPES:
                             mtype = 's'
-                        elif itype in ['TD','TS','HU']:
+                        elif itype in constants.TROPICAL_ONLY_STORM_TYPES:
                             mtype = 'o'
                         if prop['fillcolor'] == 'category':
                             ncol = get_colors_sshws(np.nan_to_num(iwnd))
@@ -1018,7 +1019,7 @@ None,prop={},map_prop={}):
             #Plot forecast dots
             for i,(ilon,ilat,itype,iwnd,ihr) in enumerate(zip(fcst_lon,fcst_lat,fcst_type,fcst_vmax,iter_hr)):
                 mtype = '^'
-                if itype in ['SD','SS']:
+                if itype in constants.SUBTROPICAL_ONLY_STORM_TYPES:
                     mtype = 's'
                 elif itype in ['TD','TS','HU','']:
                     mtype = 'o'
@@ -1100,7 +1101,7 @@ None,prop={},map_prop={}):
         if all_nan(first_fcst_wind) == True:
             storm_type = 'Unknown'
         else:
-            subtrop = True if first_fcst_type in ['SD','SS'] else False
+            subtrop = True if first_fcst_type in constants.SUBTROPICAL_ONLY_STORM_TYPES else False
             cur_wind = first_fcst_wind + 0
             storm_type = get_storm_classification(np.nan_to_num(cur_wind),subtrop,'north_atlantic')
         
@@ -1111,8 +1112,8 @@ None,prop={},map_prop={}):
                 storm_name = storm_data['name']
             else:
                 storm_name = num_to_text(int(storm_data['id'][2:4])).upper()
-                if first_fcst_wind >= 34 and first_fcst_type in ['TD','SD','SS','TS','HU']: storm_name = storm_data['name'];
-                if first_fcst_type not in ['TD','SD','SS','TS','HU']: storm_type = 'Potential Tropical Cyclone'
+                if first_fcst_wind >= 34 and first_fcst_type in constants.TROPICAL_STORM_TYPES: storm_name = storm_data['name'];
+                if first_fcst_type not in constants.TROPICAL_STORM_TYPES: storm_type = 'Potential Tropical Cyclone'
         else:
             storm_name = num_to_text(int(storm_data['id'][2:4])).upper()
             storm_type = 'Potential Tropical Cyclone'
@@ -1122,14 +1123,14 @@ None,prop={},map_prop={}):
                 storm_name = storm_data['name']
             else:
                 for i,(iwnd,ityp) in enumerate(zip(vmax,styp)):
-                    if ityp in ['SD','SS','TD','TS','HU']:
+                    if ityp in constants.TROPICAL_STORM_TYPES:
                         storm_tropical = True
-                        subtrop = True if ityp in ['SD','SS'] else False
+                        subtrop = True if ityp in constants.SUBTROPICAL_ONLY_STORM_TYPES else False
                         storm_type = get_storm_classification(np.nan_to_num(iwnd),subtrop,'north_atlantic')
                         if np.isnan(iwnd) == True: storm_type = 'Unknown'
                     else:
                         if storm_tropical == True: storm_type = 'Post Tropical Cyclone'
-                    if ityp in ['SS','TS','HU']:
+                    if ityp in constants.NAMED_TROPICAL_STORM_TYPES:
                         storm_name = storm_data['name']
         
         #Fix storm types for non-NHC basins
@@ -1583,7 +1584,7 @@ None,prop={},map_prop={}):
 
                 #For tropical/subtropical types, color-code if requested
                 if i > 0:
-                    if i_type in ['SD','TD','SS','TS','HU'] and storm['type'][i-1] in ['SD','TD','SS','TS','HU']:
+                    if i_type in constants.TROPICAL_STORM_TYPES and storm['type'][i-1] in constants.TROPICAL_STORM_TYPES:
 
                         #Plot underlying black and overlying colored line
                         self.ax.plot([lons[i-1],lons[i]],[storm['lat'][i-1],storm['lat'][i]],'-',
@@ -1631,9 +1632,9 @@ None,prop={},map_prop={}):
                     
                     #Determine dot type
                     marker_type = '^'
-                    if i_type in ['SD','SS']:
+                    if i_type in constants.SUBTROPICAL_ONLY_STORM_TYPES:
                         marker_type = 's'
-                    elif i_type in ['TD','TS','HU']:
+                    elif i_type in constants.TROPICAL_ONLY_STORM_TYPES:
                         marker_type = 'o'
                     
                     #Plot marker

--- a/src/tropycal/tracks/season.py
+++ b/src/tropycal/tracks/season.py
@@ -304,7 +304,7 @@ class Season:
         """
         
         #Determine if season object has a single or multiple seasons
-        multi_season = True if isinstance(self.year,list) == True else False
+        multi_season = isinstance(self.year,list)
         
         #Initialize dict with info about all of year's storms
         if multi_season == False:

--- a/src/tropycal/tracks/season.py
+++ b/src/tropycal/tracks/season.py
@@ -13,7 +13,8 @@ from .storm import Storm
 #Import tools
 from .tools import *
 from ..utils import *
-    
+from .. import constants
+
 class Season:
     
     r"""
@@ -407,7 +408,7 @@ class Season:
                 #Handle operational vs. non-operational storms
 
                 #Check for purely subtropical storms
-                if 'SS' in temp_type and True not in np.isin(temp_type,['TD','TS','HU']):
+                if 'SS' in temp_type and True not in np.isin(temp_type,constants.TROPICAL_ONLY_STORM_TYPES):
                     count_ss_pure += 1
 
                 #Check for partially subtropical storms

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -69,8 +69,8 @@ class Storm:
         
         #Format keys for summary
         type_array = np.array(self.dict['type'])
-        if self.invest: idx = np.array([True for i in type_array])
         idx = np.where((type_array == 'SD') | (type_array == 'SS') | (type_array == 'TD') | (type_array == 'TS') | (type_array == 'HU'))[0]
+        if self.invest and len(idx) == 0: idx = np.array([True for i in type_array])
         if len(idx) == 0:
             start_date = 'N/A'
             end_date = 'N/A'

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -272,7 +272,7 @@ class Storm:
         if lat is None and lon is None:
             idx = copy.copy(idx_final)
             
-        elif isinstance(lat,(int,float)) and isinstance(lon,(int,float)):
+        elif isinstance(lat,(int,np.int,np.integer,float,np.floating)) and isinstance(lon,(int,np.int,np.integer,float,np.floating)):
             dist = np.array([great_circle((lat,lon),(x,y)).kilometers for x,y in zip(NEW_STORM.lon,NEW_STORM.lat)])
             idx = np.abs(dist).argmin()
             if dist[idx]!=0:
@@ -294,22 +294,22 @@ class Storm:
             lon0,lon1 = lon
             if lat0 is None:
                 lat0 = min(NEW_STORM.lat)
-            elif not isinstance(lat0,(float,int)):
+            elif not isinstance(lat0,(int,np.int,np.integer,float,np.floating)):
                 msg = 'lat/lon bounds must be of type float/int or None.'
                 raise TypeError(msg)
             if lat1 is None:
                 lat1 = max(NEW_STORM.lat)
-            elif not isinstance(lat1,(float,int)):
+            elif not isinstance(lat1,(int,np.int,np.integer,float,np.floating)):
                 msg = 'lat/lon bounds must be of type float/int or None.'
                 raise TypeError(msg)
             if lon0 is None:
                 lon0 = min(NEW_STORM.lon)
-            elif not isinstance(lon0,(float,int)):
+            elif not isinstance(lon0,(int,np.int,np.integer,float,np.floating)):
                 msg = 'lat/lon bounds must be of type float/int or None.'
                 raise TypeError(msg)
             if lon1 is None:
                 lon1 = max(NEW_STORM.lon)
-            elif not isinstance(lon1,(float,int)):
+            elif not isinstance(lon1,(int,np.int,np.integer,float,np.floating)):
                 msg = 'lat/lon bounds must be of type float/int or None.'
                 raise TypeError(msg)
                 
@@ -335,12 +335,12 @@ class Storm:
             vmax0,vmax1 = vmax
             if vmax0 is None:
                 vmax0 = np.nanmin(NEW_STORM.vmax)
-            elif not isinstance(vmax0,(float,int)):
+            elif not isinstance(vmax0,(int,np.int,np.integer,float,np.floating)):
                 msg = 'vmax bounds must be of type float/int or None.'
                 raise TypeError(msg)
             if vmax1 is None:
                 vmax1 = np.nanmax(NEW_STORM.vmax)
-            elif not isinstance(vmax1,(float,int)):
+            elif not isinstance(vmax1,(int,np.int,np.integer,float,np.floating)):
                 msg = 'vmax bounds must be of type float/int or None.'
                 raise TypeError(msg)            
             tmpvmax = np.array(NEW_STORM.vmax)
@@ -364,12 +364,12 @@ class Storm:
             mslp0,mslp1 = mslp
             if mslp0 is None:
                 mslp0 = np.nanmin(NEW_STORM.mslp)
-            elif not isinstance(mslp0,(float,int)):
+            elif not isinstance(mslp0,(int,np.int,np.integer,float,np.floating)):
                 msg = 'mslp bounds must be of type float/int or None.'
                 raise TypeError(msg)
             if mslp1 is None:
                 mslp1 = np.nanmax(NEW_STORM.mslp)
-            elif not isinstance(mslp1,(float,int)):
+            elif not isinstance(mslp1,(int,np.int,np.integer,float,np.floating)):
                 msg = 'mslp bounds must be of type float/int or None.'
                 raise TypeError(msg)            
             tmpmslp = np.array(NEW_STORM.mslp)
@@ -397,12 +397,12 @@ class Storm:
             dvmax_dt0,dvmax_dt1 = dvmax_dt
             if dvmax_dt0 is None:
                 dvmax_dt0 = np.nanmin(NEW_STORM.dvmax_dt)
-            elif not isinstance(dvmax_dt0,(float,int)):
+            elif not isinstance(dvmax_dt0,(int,np.int,np.integer,float,np.floating)):
                 msg = 'dmslp_dt bounds must be of type float/int or None.'
                 raise TypeError(msg)
             if dvmax_dt1 is None:
                 dvmax_dt1 = np.nanmax(NEW_STORM.dvmax_dt)
-            elif not isinstance(dvmax_dt1,(float,int)):
+            elif not isinstance(dvmax_dt1,(int,np.int,np.integer,float,np.floating)):
                 msg = 'dmslp_dt bounds must be of type float/int or None.'
                 raise TypeError(msg)     
                         
@@ -427,12 +427,12 @@ class Storm:
             dmslp_dt0,dmslp_dt1 = dmslp_dt
             if dmslp_dt0 is None:
                 dmslp_dt0 = np.nanmin(NEW_STORM.dmslp_dt)
-            elif not isinstance(dmslp_dt0,(float,int)):
+            elif not isinstance(dmslp_dt0,(int,np.int,np.integer,float,np.floating)):
                 msg = 'dmslp_dt bounds must be of type float/int or None.'
                 raise TypeError(msg)
             if dmslp_dt1 is None:
                 dmslp_dt1 = np.nanmax(NEW_STORM.dmslp_dt)
-            elif not isinstance(dmslp_dt1,(float,int)):
+            elif not isinstance(dmslp_dt1,(int,np.int,np.integer,float,np.floating)):
                 msg = 'dmslp_dt bounds must be of type float/int or None.'
                 raise TypeError(msg)            
             tmpmslp = np.array(NEW_STORM.dmslp_dt)

--- a/src/tropycal/tracks/tools.py
+++ b/src/tropycal/tracks/tools.py
@@ -10,6 +10,8 @@ import matplotlib.colors as mcolors
 import matplotlib as mlib
 import warnings
 
+from .. import constants
+
 def find_var(request,thresh):
     
     r"""
@@ -294,9 +296,9 @@ def interp_storm(storm_dict,timeres=1,dt_window=24,dt_align='middle'):
         new_storm['wmo_basin'] = [basindict[k] for k in basininterp]
         
         #Interpolate and fill in storm type
-        stormtype = [1 if i in ('TD','SD','TS','SS','HU') else -1 for i in storm_dict['type']]
+        stormtype = [1 if i in constants.TROPICAL_STORM_TYPES else -1 for i in storm_dict['type']]
         isTROP = np.interp(targettimes,times,stormtype)
-        stormtype = [1 if i in ('SD','SS') else -1 for i in storm_dict['type']]
+        stormtype = [1 if i in constants.SUBTROPICAL_ONLY_STORM_TYPES else -1 for i in storm_dict['type']]
         isSUB = np.interp(targettimes,times,stormtype)
         stormtype = [1 if i=='LO' else -1 for i in storm_dict['type']]
         isLO = np.interp(targettimes,times,stormtype)


### PR DESCRIPTION
Several bug fixes:

- Some post-tropical cyclones have had their storm type incorrectly assigned as a tropical cyclone in ``RealtimeStorm.get_realtime_info()``. This has been changed to "Post-Tropical Cyclone".
- Storm plotting functions are split between dashed lines for non-tropical cyclones and solid lines for tropical cyclones. The immediate timestep before a TC forms was plotted with a solid black line, but has been changed to a thin black line.
- When adding invest handling capability for Tropycal v0.3, a case that wasn't considered is a tropical cyclone which became post-tropical, then re-assigned as an invest to monitor the potential for re-transitioning into a tropical cyclone. The resulting unintended behavior was for Realtime objects to re-assign those as active tropical cyclones, even though no operational products are produced for such cases. This bug fix reassigns any post-tropical cyclone that has not been tropical for 18+ hours as an invest.
- When reading in JTWC data into a Realtime object, the "TY" typhoon storm type is reassigned to "HU" (hurricane) for continuity purposes between different basins. For some data sources, a Super Typhoon "ST" storm type is included, which was previously not accounted for, resulting in an incorrect classification as an extratropical cyclone. This bug fixes ensures super typhoons are also reassigned to a "HU" storm type.