### PR TITLE
Bug fixes & update to v0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tropycal is a Python package intended to simplify the process of retrieving and 
 
 Tropycal can read in HURDAT2 and IBTrACS reanalysis data and operational National Hurricane Center (NHC) Best Track data and conform them to the same format, which can be used to perform climatological, seasonal and individual storm analyses. For each individual storm, operational NHC forecasts, aircraft reconnaissance data, and any associated tornado activity can be retrieved and plotted.
 
-The latest version of Tropycal is v0.3.
+The latest version of Tropycal is v0.3.1.
 
 ## Installation
 
@@ -39,7 +39,6 @@ python setup.py install
 - numpy >= 1.14.3
 - scipy >= 1.1.0
 - pandas >= 0.23.0
-- geopy >= 1.18.1
 - xarray >= 0.10.7
 - networkx >= 2.0.0
 - requests >= 2.22.0
@@ -49,7 +48,7 @@ To fully leverage tropycal's plotting capabilities, it is strongly recommended t
 ## Documentation
 For full documentation and examples, please refer to [Tropycal Documentation](https://tropycal.github.io/tropycal/).
 
-As of v0.2.5, the documentation available online is outdated. The latest documentation available is for v0.2.4. A fix is ongoing to get documentation working again and published online, but with the publication date TBD.
+As of v0.3, the documentation is up-to-date following a bug that started with v0.2.5 where the documentation was not updated with each release.
 
 ## Sample Usage
 As an example, read in the North Atlantic HURDAT2 reanalysis dataset, excluding Best Track (current year's storms):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ author = 'Tropycal Developers'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.3.1'
+release = '0.3.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Tropycal is supported for Python >= 3.6. For examples on how to use Tropycal in 
 Latest Version
 ==============
 
-The latest version of Tropycal as of 4 October 2021 is v0.3.1. This documentation is valid for the latest version of Tropycal.
+The latest version of Tropycal as of 15 February 2022 is v0.3.2. This documentation is valid for the latest version of Tropycal.
 
 Indices and tables
 ==================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,7 +12,6 @@ The primary dependencies of tropycal are as follows:
 * numpy >= 1.14.3
 * scipy >= 1.1.0
 * pandas >= 0.23.0
-* geopy >= 1.18.1
 * xarray >= 0.10.7
 * networkx >= 2.0.0
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 numpy >= 1.14.3
 pandas >= 0.23.0
 scipy >= 1.1.0
-geopy >= 1.18.1
 matplotlib >= 2.2.2
 networkx

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tropycal
-version = 0.3.1
+version = 0.3.2
 description = Package for retrieving and analyzing tropical cyclone data
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/tropycal/plot/plot.py
+++ b/src/tropycal/plot/plot.py
@@ -234,8 +234,14 @@ class Plot:
             #Second call with labels but no gridlines
             gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,xlocs=meridians,ylocs=parallels,linewidth=0.0,color='k',alpha=0.0,linestyle='dotted',**add_kwargs)
             
-            gl.xlabels_top = False
-            gl.ylabels_right = False
+            #this syntax is deprecated in newer functions of cartopy
+            try:
+                gl.xlabels_top = False
+                gl.ylabels_right = False
+            except:
+                gl.top_labels = False
+                gl.right_labels = False
+            
             gl.xlocator = mticker.FixedLocator(meridians2)
             gl.ylocator = mticker.FixedLocator(parallels)
             gl.xformatter = LONGITUDE_FORMATTER
@@ -244,8 +250,15 @@ class Plot:
         else:
             #Add meridians and parallels
             gl = self.ax.gridlines(crs=ccrs.PlateCarree(),draw_labels=True,linewidth=1.0,color='k',alpha=0.5,linestyle='dotted',**add_kwargs)
-            gl.xlabels_top = False
-            gl.ylabels_right = False
+            
+            #this syntax is deprecated in newer functions of cartopy
+            try:
+                gl.xlabels_top = False
+                gl.ylabels_right = False
+            except:
+                gl.top_labels = False
+                gl.right_labels = False
+            
             gl.xlocator = mticker.FixedLocator(meridians)
             gl.ylocator = mticker.FixedLocator(parallels)
             gl.xformatter = LONGITUDE_FORMATTER

--- a/src/tropycal/plot/plot.py
+++ b/src/tropycal/plot/plot.py
@@ -276,10 +276,11 @@ class Plot:
             self.fig = plt.figure(figsize=map_prop['figsize'],dpi=map_prop['dpi'])
             self.ax = plt.axes(projection=self.proj)
         else:
-            # get the figure numbers of all existing figures
             fig_numbers = [x.num for x in mlib._pylab_helpers.Gcf.get_all_fig_managers()]
-            # set figure as last figure number
-            self.fig = plt.figure(fig_numbers[-1])
+            if len(fig_numbers) > 0:
+                self.fig = plt.figure(fig_numbers[-1])
+            else:
+                self.fig = plt.figure(figsize=map_prop['figsize'],dpi=map_prop['dpi'])
             self.ax = ax
         
         #Attach geography to plot, lat/lon lines, etc.

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -304,6 +304,23 @@ class Realtime():
                     if btk_type in constants.NAMED_TROPICAL_STORM_TYPES:
                         self.data[stormid]['ace'] += np.round(ace,4)
 
+            #Determine storm name for invests
+            if invest_bool == True:
+                
+                #Determine letter in front of invest
+                add_letter = 'L'
+                if stormid[0] == 'C':
+                    add_letter = 'C'
+                elif stormid[0] == 'E':
+                    add_letter = 'E'
+                elif stormid[0] == 'W':
+                    add_letter = 'W'
+                elif stormid[0] == 'I':
+                    add_letter = 'I'
+                elif stormid[0] == 'S':
+                    add_letter = 'S'
+                name = stormid[2:4] + add_letter
+            
             #Add storm name
             self.data[stormid]['name'] = name
             
@@ -334,7 +351,7 @@ class Realtime():
 
         #Get relevant filenames from directory
         files = []
-        search_pattern = f'b[isw][ohp][01234][0123456789]{current_year}.dat'
+        search_pattern = f'b[isw][ohp][012349][0123456789]{current_year}.dat'
 
         pattern = re.compile(search_pattern)
         filelist = pattern.findall(string)
@@ -342,7 +359,7 @@ class Realtime():
             if filename not in files: files.append(filename)
         
         #Search for following year (for SH storms)
-        search_pattern = f'b[isw][ohp][01234][0123456789]{current_year+1}.dat'
+        search_pattern = f'b[isw][ohp][012349][0123456789]{current_year+1}.dat'
 
         pattern = re.compile(search_pattern)
         filelist = pattern.findall(string)
@@ -354,6 +371,11 @@ class Realtime():
 
             #Get file ID
             stormid = ((file.split(".dat")[0])[1:]).upper()
+            
+            #Check for invest status
+            invest_bool = False
+            if int(stormid[2]) == 9:
+                invest_bool = True
 
             #Determine basin based on where storm developed
             add_basin = 'west_pacific'
@@ -363,7 +385,7 @@ class Realtime():
                 add_basin = ''
 
             #add empty entry into dict
-            self.data[stormid] = {'id':stormid,'operational_id':stormid,'name':'','year':int(stormid[4:8]),'season':int(stormid[4:8]),'basin':add_basin,'source_info':'Joint Typhoon Warning Center','realtime':True,'invest':False}
+            self.data[stormid] = {'id':stormid,'operational_id':stormid,'name':'','year':int(stormid[4:8]),'season':int(stormid[4:8]),'basin':add_basin,'source_info':'Joint Typhoon Warning Center','realtime':True,'invest':invest_bool}
             self.data[stormid]['source'] = 'jtwc'
             
             #Add source info
@@ -460,6 +482,23 @@ class Realtime():
                     if btk_type in constants.NAMED_TROPICAL_STORM_TYPES:
                         self.data[stormid]['ace'] += np.round(ace,4)
 
+            #Determine storm name for invests
+            if invest_bool == True:
+                
+                #Determine letter in front of invest
+                add_letter = 'L'
+                if stormid[0] == 'C':
+                    add_letter = 'C'
+                elif stormid[0] == 'E':
+                    add_letter = 'E'
+                elif stormid[0] == 'W':
+                    add_letter = 'W'
+                elif stormid[0] == 'I':
+                    add_letter = 'I'
+                elif stormid[0] == 'S':
+                    add_letter = 'S'
+                name = stormid[2:4] + add_letter
+            
             #Add storm name
             self.data[stormid]['name'] = name
             

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -365,6 +365,18 @@ class Realtime():
         filelist = pattern.findall(string)
         for filename in filelist:
             if filename not in files: files.append(filename)
+        
+        if source in ['jtwc','ucar']:
+            try:
+                urlpath_nextyear = urllib.request.urlopen(url.replace(str(current_year),str(current_year+1)))
+                string_nextyear = urlpath_nextyear.read().decode('utf-8')
+
+                pattern = re.compile(search_pattern)
+                filelist = pattern.findall(string_nextyear)
+                for filename in filelist:
+                    if filename not in files: files.append(filename)
+            except:
+                pass
 
         #For each file, read in file content and add to hurdat dict
         for file in files:
@@ -407,6 +419,7 @@ class Realtime():
             url = f"https://www.nrlmry.navy.mil/atcf_web/docs/tracks/{current_year}/{file}"
             if source == 'noaa': url = f"https://www.ssd.noaa.gov/PS/TROP/DATA/ATCF/JTWC/{file}"
             if source == 'ucar': url = f"http://hurricanes.ral.ucar.edu/repository/data/bdecks_open/{current_year}/{file}"
+            if f"{current_year+1}.dat" in url: url = url.replace(str(current_year),str(current_year+1))
             f = urllib.request.urlopen(url)
             content = f.read()
             content = content.decode("utf-8")

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -313,8 +313,16 @@ class TrackDataset:
                 #Retrieve important info about storm
                 yyyymmdd,hhmm,special,storm_type,lat,lon,vmax,mslp = line[0:8]
                 
-                #Parse into format to be entered into dict
+                #Check date doesn't already exist in dict
                 date = dt.strptime(yyyymmdd+hhmm,'%Y%m%d%H%M')
+                if date in self.data[current_id]['date']:
+                    #Hard-code fix
+                    if current_id == "AL151966" and yyyymmdd == "19661004":
+                        date = dt.strptime("19661006"+hhmm,'%Y%m%d%H%M')
+                    else:
+                        continue
+                
+                #Parse into format to be entered into dict
                 if "N" in lat:
                     lat = float(lat.split("N")[0])
                 elif "S" in lat:

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -284,6 +284,12 @@ class TrackPlot(Plot):
                 add_letter = 'C'
             elif storm_data['id'][0] == 'E':
                 add_letter = 'E'
+            elif storm_data['id'][0] == 'W':
+                add_letter = 'W'
+            elif storm_data['id'][0] == 'I':
+                add_letter = 'I'
+            elif storm_data['id'][0] == 'S':
+                add_letter = 'S'
             
             #Add title
             self.ax.set_title(f"INVEST {storm_data['id'][2:4]}{add_letter}",loc='left',fontsize=17,fontweight='bold')

--- a/src/tropycal/utils/generic_utils.py
+++ b/src/tropycal/utils/generic_utils.py
@@ -318,7 +318,7 @@ def get_basin(lat,lon,storm_id=""):
         elif lon < 180.0:
             return "west_pacific"
         else:
-            if len(storm_id) != 9:
+            if len(storm_id) != 8:
                 msg = "Cannot determine whether storm is in North Atlantic or East Pacific basins."
                 raise RuntimeError(msg)
             if storm_id[0:2] == "AL":


### PR DESCRIPTION
Numerous bug fixes that necessitate an update to v0.3.2:

- Invest functionality was added previously to Realtime objects, but not to global invests. This update adds global invests.
- Geopy was removed as a dependence a while back, but was not entirely removed from the package configuration script. This bug fix removes any remaining Geopy mention.
- Fix a bug with storm ID length in the utility `get_basin()` function.
- Identified and fixed a bug where storms at the end of a calendar year in the Southern Hemisphere that had an ID for the following year (e.g., "SH012022" in November 2021) weren't identified in Realtime objects.
- Fixed a bug that prevented multiple functions from using the same axis.
- Fixed a bug with the Cartopy lat/lon label syntax that was changed in newer Cartopy versions.
- Hard-coded a fix for reading HURDATv2 data, as a recent change to the default URL used for HURDATv2 inadvertently created duplicate entries
- SPC's tornado database hasn't updated through 2020 nor 2021, as 2019 remains the most recent year available. This change to TornadoDataset ensures the last 5 years are checked for the most recent year containing tornado data.