### PR TITLE
Fix JTWC SSL certificate issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ author = 'Tropycal Developers'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.3.2'
+release = '0.3.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Tropycal is supported for Python >= 3.6. For examples on how to use Tropycal in 
 Latest Version
 ==============
 
-The latest version of Tropycal as of 15 February 2022 is v0.3.2. This documentation is valid for the latest version of Tropycal.
+The latest version of Tropycal as of 17 February 2022 is v0.3.3. This documentation is valid for the latest version of Tropycal.
 
 Indices and tables
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tropycal
-version = 0.3.2
+version = 0.3.3
 description = Package for retrieving and analyzing tropical cyclone data
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/tropycal/realtime/realtime.py
+++ b/src/tropycal/realtime/realtime.py
@@ -151,6 +151,8 @@ class Realtime():
             hours_diff = (current_date - last_date).total_seconds() / 3600.0
             if hours_diff >= 18.0 or (self.data[key]['invest'] and hours_diff >= 9.0):
                 del self.data[key]
+            if hours_diff <= -48.0:
+                del self.data[key]
         
         #For each storm remaining, create a Storm object
         if len(self.data) > 0:

--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -713,6 +713,9 @@ class RealtimeStorm(Storm):
                         current_advisory['type'] = 'Potential Tropical Cyclone'
                 else:
                     current_advisory['type'] = 'Post-Tropical Cyclone'
+            elif self.source in ['jtwc','ucar']:
+                if self.invest:
+                    current_advisory['type'] = 'Invest'
 
             #Get storm name
             current_advisory['name'] = self.name.title()


### PR DESCRIPTION
JTWC's server has had SSL certificate error messages in recent days preventing the data from being read into Realtime objects. This bug fix allows an option to bypass SSL certification - by default this option is turned off, and should only be used in limited circumstances such as the current one.

Edit: I added another bug fix for invest labeling for realtime invests in JTWC's basin (as invests may occasionally use tropical cyclone type labeling).

Edit 2: I added another bug fix for realtime invests in JTWC - the directory sometimes stores "future" invests (e.g., files containing dates 1 year from now), so this fix filters those out.