### PR TITLE
inverse_transformed was removed in matplotlib 3.5.0, deprecated in 3.3.0 

### DIFF
--- a/src/tropycal/rain/plot.py
+++ b/src/tropycal/rain/plot.py
@@ -429,7 +429,7 @@ class RainPlot(Plot):
             plt.draw()
             
             #Get the bbox
-            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+            bb = l.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
@@ -466,7 +466,7 @@ class RainPlot(Plot):
             plt.draw()
             
             #Get the bbox
-            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+            bb = l.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])

--- a/src/tropycal/recon/plot.py
+++ b/src/tropycal/recon/plot.py
@@ -205,7 +205,7 @@ class ReconPlot(Plot):
         plt.draw()
 
         #Get the bbox
-        bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+        bb = l.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
         bb_ax = self.ax.get_position()
 
         #Define colorbar axis
@@ -393,7 +393,7 @@ class ReconPlot(Plot):
         plt.draw()
 
         #Get the bbox
-        bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+        bb = l.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
         bb_ax = self.ax.get_position()
 
         #Define colorbar axis

--- a/src/tropycal/tornado/plot.py
+++ b/src/tropycal/tornado/plot.py
@@ -184,7 +184,7 @@ class TornadoPlot(Plot):
         plt.draw()
 
         # Get the bbox
-        bb = leg_tor.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+        bb = leg_tor.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
         bb_ax = self.ax.get_position()
 
         rectangle = mpatches.Rectangle((bb_ax.x0,bb_ax.y0),bb.width+bb.x0-bb_ax.x0,bb.height+2*bb.y0-2*bb_ax.y0,\

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -372,7 +372,7 @@ class TrackPlot(Plot):
             plt.draw()
             
             #Get the bbox
-            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+            bb = l.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
@@ -409,7 +409,7 @@ class TrackPlot(Plot):
             plt.draw()
             
             #Get the bbox
-            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+            bb = l.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
@@ -712,7 +712,7 @@ class TrackPlot(Plot):
             plt.draw()
             
             #Get the bbox
-            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+            bb = l.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
@@ -749,7 +749,7 @@ class TrackPlot(Plot):
             plt.draw()
             
             #Get the bbox
-            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+            bb = l.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
@@ -1748,7 +1748,7 @@ None,prop={},map_prop={}):
             plt.draw()
             
             #Get the bbox
-            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+            bb = l.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
@@ -1785,7 +1785,7 @@ None,prop={},map_prop={}):
             plt.draw()
             
             #Get the bbox
-            bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+            bb = l.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
                 
             #Define colorbar axis
             cax = self.fig.add_axes([bb.x0+0.47*bb.width, bb.y0+.057*bb.height, 0.015, .65*bb.height])
@@ -2325,7 +2325,7 @@ None,prop={},map_prop={}):
         plt.draw()
 
         #Get the bbox
-        bb = l.legendPatch.get_bbox().inverse_transformed(self.fig.transFigure)
+        bb = l.legendPatch.get_bbox().inverted().transform(self.fig.transFigure)
         bb_ax = self.ax.get_position()
 
         #Define colorbar axis


### PR DESCRIPTION
inverted().transform appears to be the new syntax 

https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.5.0.html?highlight=inverse_transformed

"Return the corresponding inverse transformation.
It holds x == self.inverted().transform(self.transform(x))." 

https://matplotlib.org/stable/api/transformations.html

