### PR TITLE
Bug fixes & increment to v0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tropycal is a Python package intended to simplify the process of retrieving and 
 
 Tropycal can read in HURDAT2 and IBTrACS reanalysis data and operational National Hurricane Center (NHC) Best Track data and conform them to the same format, which can be used to perform climatological, seasonal and individual storm analyses. For each individual storm, operational NHC and model forecasts, aircraft reconnaissance data, rainfall data, and any associated tornado activity can be retrieved and plotted.
 
-The latest version of Tropycal is v0.5.1.
+The latest version of Tropycal is v0.5.2.
 
 ## Installation
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,13 +27,13 @@ sys.path.insert(0, os.path.abspath('../plot'))
 # -- Project information -----------------------------------------------------
 
 project = 'tropycal'
-copyright = '2021, Tropycal Developers'
+copyright = '2022, Tropycal Developers'
 author = 'Tropycal Developers'
 
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.5.1'
+release = '0.5.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Tropycal is supported for Python >= 3.6. For examples on how to use Tropycal in 
 Latest Version
 ==============
 
-The latest version of Tropycal as of 22 July 2022 is v0.5.1. This documentation is valid for the latest version of Tropycal.
+The latest version of Tropycal as of 16 August 2022 is v0.5.2. This documentation is valid for the latest version of Tropycal.
 
 Indices and tables
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tropycal
-version = 0.5.1
+version = 0.5.2
 description = Package for retrieving and analyzing tropical cyclone data
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -1005,13 +1005,6 @@ class TrackDataset:
             if len(self.data[key]['lat']) == 0:
                 del(self.data[key])
         
-        #Remove entries where requested basin doesn't appear
-        if self.basin not in ['all','both']:
-            all_keys = [k for k in self.data.keys()]
-            for key in all_keys:
-                if self.basin not in self.data[key]['wmo_basin']:
-                    del(self.data[key])
-        
         #Replace neumann entries
         if self.neumann:
             
@@ -1028,7 +1021,14 @@ class TrackDataset:
                 
                 #replace id
                 self.data[jtwc_id]['id'] = jtwc_id
-                
+        
+        #Remove entries where requested basin doesn't appear
+        if self.basin not in ['all','both']:
+            all_keys = [k for k in self.data.keys()]
+            for key in all_keys:
+                if self.basin not in self.data[key]['wmo_basin']:
+                    del(self.data[key])
+        
         #Fix cyclone Catarina, if specified & requested
         all_keys = [k for k in self.data.keys()]
         if '2004086S29318' in all_keys and self.catarina:

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -3844,7 +3844,7 @@ class TrackDataset:
         
         return ax
 
-    def plot_summary(self,time,domain='all',ax=None,cartopy_proj=None,save_path=None,**kwargs):
+    def plot_summary(self,time,domain=None,ax=None,cartopy_proj=None,save_path=None,**kwargs):
         
         r"""
         Plot a summary map of past tropical cyclone and NHC potential development activity. Only valid for areas in NHC's area of responsibility at this time.
@@ -3854,7 +3854,7 @@ class TrackDataset:
         time : datetime
             Valid time for the summary plot.
         domain : str
-            Domain for the plot. Default is "all". Please refer to :ref:`options-domain` for available domain options.
+            Domain for the plot. Default is current basin. Please refer to :ref:`options-domain` for available domain options.
         ax : axes, optional
             Instance of axes to plot on. If none, one will be generated. Default is none.
         cartopy_proj : ccrs, optional
@@ -3950,6 +3950,10 @@ class TrackDataset:
         #Error check
         if self.source != 'hurdat':
             raise RuntimeError("This function is only available for NHC's area of responsibility at this time.")
+        
+        #Set basin
+        if domain == None:
+            domain = self.basin
         
         #Find closest NHC shapefile
         shapefiles = get_two_archive(time)

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -4074,6 +4074,11 @@ class TrackDataset:
             track_dict['prob_5day'] = 'N/A'
             track_dict['risk_5day'] = 'N/A'
             
+            #Fill empty observed dicts (assuming storm just formed)
+            if len(track_dict['lat']) == 0:
+                for iter_key in ['lat','lon','vmax','mslp','type']:
+                    track_dict[iter_key] = [forecast_dict[iter_key][0]]
+            
             track_dict['basin'] = storm.basin
             storms.append(Storm(track_dict))
             forecasts.append(forecast_dict)

--- a/src/tropycal/tracks/plot.py
+++ b/src/tropycal/tracks/plot.py
@@ -2273,6 +2273,9 @@ None,prop={},map_prop={}):
                     color = get_colors_sshws(storm.vmax[-1])
                     if category == "0": category = 'S'
                     if category == "-1": category = 'D'
+                    if np.isnan(storm.vmax[-1]):
+                        category = 'U'
+                        color = 'w'
                     
                     if storm_prop['fillcolor'] == 'none':
                         self.ax.plot(storm.lon[-1],storm.lat[-1],'o',ms=storm_prop['ms'],color='none',mec='k',mew=3.0,transform=ccrs.PlateCarree(),zorder=20)
@@ -2330,16 +2333,19 @@ None,prop={},map_prop={}):
                                 if forecast_dict['fhr'][idx]/24.0 > cone_prop['days']: continue
                                 if cone_prop['ms'] == 0: continue
                                 color = get_colors_sshws(forecast_dict['vmax'][idx])
+                                if np.isnan(forecast_dict['vmax'][idx]): color = 'w'
                                 if cone_prop['fillcolor'] != 'category': color = cone_prop['fillcolor']
                                 
                                 marker = 'o'
                                 if forecast_dict['type'][idx] not in constants.TROPICAL_STORM_TYPES: marker = '^'
+                                if np.isnan(forecast_dict['vmax'][idx]): marker = 'o'
                                 self.ax.plot(forecast_dict['lon'][idx],forecast_dict['lat'][idx],marker,ms=cone_prop['ms'],mfc=color,mec='k',zorder=7,transform=ccrs.PlateCarree(),clip_on=True)
 
                                 if cone_prop['label_category'] == True and marker == 'o':
                                     category = str(wind_to_category(forecast_dict['vmax'][idx]))
                                     if category == "0": category = 'S'
                                     if category == "-1": category = 'D'
+                                    if np.isnan(forecast_dict['vmax'][idx]): category = 'U'
 
                                     color = mcolors.to_rgb(color)
                                     red,green,blue = color

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -2155,24 +2155,19 @@ class Storm:
         #Follow JTWC procedure
         else:
             
-            #Get storm ID & corresponding data URL
-            storm_year = self.dict['year']
-            if storm_year < 2019:
-                msg = "Forecast data is unavailable for JTWC storms prior to 2019."
-                raise RuntimeError(msg)
-            url_models = f"http://hurricanes.ral.ucar.edu/repository/data/adecks_open/{self.year}/a{self.id.lower()}.dat"
+            url_models_noaa = f"https://www.ssd.noaa.gov/PS/TROP/DATA/ATCF/JTWC/a{self.id.lower()}.dat"
+            url_models_ucar = f"http://hurricanes.ral.ucar.edu/repository/data/adecks_open/{self.year}/a{self.id.lower()}.dat"
             
             #Retrieve model data text
             try:
-                f = urllib.request.urlopen(url_models)
-                content = f.read()
-                content = content.decode("utf-8")
-                content = content.split("\n")
-                content = [i.split(",") for i in content]
-                content = [i for i in content if len(i) > 10]
-                f.close()
+                content = read_url(url_models_noaa,split=True,subsplit=False)
             except:
-                raise RuntimeError("No operational model data is available for this storm.")
+                try:
+                    content = read_url(url_models_ucar,split=True,subsplit=False)
+                except:
+                    raise RuntimeError("No operational model data is available for this storm.")
+            content = [i.split(",") for i in content]
+            content = [i for i in content if len(i) > 10]
 
         #Iterate through every line in content:
         forecasts = {}

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -2181,11 +2181,15 @@ class Storm:
             except:
                 basin,number,run_init,n_a,model,fhr,lat,lon,vmax,mslp,stype = lineArray[:11]
                 use_wind = False
-
+            
+            #Check init date is within storm date range
+            run_init_dt = dt.strptime(run_init,'%Y%m%d%H')
+            if run_init_dt < self.dict['date'][0]-timedelta(hours=6) or run_init_dt > self.dict['date'][-1]+timedelta(hours=6): continue
+            
             #Enter into forecast dict
             if model not in forecasts.keys(): forecasts[model] = {}
             if run_init not in forecasts[model].keys(): forecasts[model][run_init] = {
-                'init':dt.strptime(run_init,'%Y%m%d%H'),'fhr':[],'lat':[],'lon':[],'vmax':[],'mslp':[],'type':[],'windrad':[]
+                'init':run_init_dt,'fhr':[],'lat':[],'lon':[],'vmax':[],'mslp':[],'type':[],'windrad':[]
             }
 
             #Format lat & lon
@@ -2258,7 +2262,7 @@ class Storm:
             else:
                 ifhr = forecasts[model][run_init]['fhr'].index(fhr)
                 forecasts[model][run_init]['windrad'][ifhr][rad]=[neq,seq,swq,nwq]
-                
+        
         #Save dict locally
         self.forecast_dict = forecasts
         

--- a/src/tropycal/utils/generic_utils.py
+++ b/src/tropycal/utils/generic_utils.py
@@ -581,7 +581,7 @@ def get_two_archive(time):
     diff = [i for i in diff if i >= 0]
 
     #Continue if less than 24 hours difference
-    if np.nanmin(diff) <= 30:
+    if len(diff) > 0 and np.nanmin(diff) <= 30:
         two_date = dates[diff.index(np.nanmin(diff))].strftime('%Y%m%d%H%M')
 
         #Retrieve NHC shapefiles for development areas

--- a/src/tropycal/utils/generic_utils.py
+++ b/src/tropycal/utils/generic_utils.py
@@ -605,6 +605,17 @@ def get_two_archive(time):
                 files = []
                 for file in filelist:
                     if file not in files: files.append(file.split(".shp")[0]) #remove duplicates
+                
+                #Alternatively, check files for older format (generally 2014 and earlier)
+                if len(files) == 0:
+                    if name in ['lines','points']:
+                        shapefiles[name] = None
+                        continue
+                    search_pattern = f'20{nums}{nums}{nums}{nums}{nums}{nums}{nums}{nums}{nums}{nums}_gtwo.shp'
+                    pattern = re.compile(search_pattern)
+                    filelist = pattern.findall(members)
+                    for file in filelist:
+                        if file not in files: files.append(file.split(".shp")[0]) #remove duplicates
 
                 #Retrieve necessary components for shapefile
                 members = tar.namelist()


### PR DESCRIPTION
This update has several bug fixes that prompt a version upgrade to v0.5.2.

## Bug fixes for ``TrackDataset.plot_summary()`` method:

- Fixed a bug where this function would crash if plotting a date where a storm had just formed.
- Changed the default plotting basin from global to the selected TrackDataset basin.
- Added the ability to plot TWOs between 2010 and 2014 using NHC's older TWO format.
- Added formation probability labels for TWO areas without an accompanying point label.
- Fixed display of storms with NaN forecast sustained wind.

## Other bug fixes

- JTWC a-decks are now preferentially retrieved from NOAA SSD, falling back to UCAR if the former is not available. This extends the a-decks back to 2016 and adds many more models in realtime not available through the UCAR a-decks.
- Forecast dictionaries for invests retrieved from ``tracks.Storm.get_operational_forecasts()`` now remove a-deck data for previous designations of the same invest number.
- Fixed a bug in creating a TrackDataset instance using the JTWC Neumann reanalysis (Issue #168).
- ``utils.get_two_archive()`` no longer crashes if a TWO is not available for prior years.
- ``utils.get_two_archive()`` can now read in TWOs using NHC's older format between 2010 and 2014.
