### PR TITLE
Upgrade to v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tropycal is a Python package intended to simplify the process of retrieving and 
 
 Tropycal can read in HURDAT2 and IBTrACS reanalysis data and operational National Hurricane Center (NHC) Best Track data and conform them to the same format, which can be used to perform climatological, seasonal and individual storm analyses. For each individual storm, operational NHC and model forecasts, aircraft reconnaissance data, rainfall data, and any associated tornado activity can be retrieved and plotted.
 
-The latest version of Tropycal is v1.1.
+The latest version of Tropycal is v1.2.
 
 ## Installation
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ author = 'Tropycal Developers'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '1.1'
+release = '1.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Tropycal is supported for Python >= 3.6. For examples on how to use Tropycal in 
 Latest Version
 ==============
 
-The latest version of Tropycal as of 21 August 2023 is v1.1. This documentation is valid for the latest version of Tropycal.
+The latest version of Tropycal as of 21 August 2023 is v1.2. This documentation is valid for the latest version of Tropycal.
 
 Indices and tables
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tropycal
-version = 1.1
+version = 1.2
 description = Package for retrieving and analyzing tropical cyclone data
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Version 1.1 was erroneously uploaded before the master branch could be successfully updated. This resolves that fix while upgrading to v1.2, thus skipping an official v1.1 release.