### PR TITLE
Add option to pass a list of times to Storm.sel

### DIFF
--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -324,6 +324,13 @@ class Storm:
                 msg = f'no points between {time}. Use different time bounds.'
                 raise ValueError(msg)
 
+        elif isinstance(time, (tuple, list)) and len(time) > 2:
+            idx = [i for i, t in enumerate(NEW_STORM.time) if t in time]
+
+            if len(idx) == 0:
+                msg = f'Storm has no points matching specified times.'
+                raise ValueError(msg)
+
         else:
             msg = 'time must be of type datetime.datetime, tuple/list, or None.'
             raise TypeError(msg)

--- a/src/tropycal/tracks/storm.py
+++ b/src/tropycal/tracks/storm.py
@@ -241,7 +241,8 @@ class Storm:
         Parameters
         ----------
         time : datetime.datetime or list/tuple of datetimes
-            Datetime object for single point, or list/tuple of start time and end time.
+            Datetime object for single point, a list/tuple of start time and end time,
+            or a list of times (length>2) to match.
             Default is None, which returns all points
         lat : float/int or list/tuple of float/int
             Float/int for single point, or list/tuple of latitude bounds (S,N).


### PR DESCRIPTION
I modified Storm.sel() so I could pass it a list of times to match as an alternative to specifying the start an the end. Thought this could be useful to add to the main library. The reason for doing it is that I wanted to compared pairs of storms over a common set of times but because the underlying data sometimes has extra times in it, doing this by specifying the start/end times can result in the storm times not matching. I added a test showing this issue.