### PR TITLE
SSL: Requests verify wants a string or path

### DIFF
--- a/src/tropycal/realtime/storm.py
+++ b/src/tropycal/realtime/storm.py
@@ -436,10 +436,7 @@ class RealtimeStorm(Storm):
             else:
                 url = f"https://www.ssd.noaa.gov/PS/TROP/DATA/ATCF/JTWC/{self.id.lower()}.fst"
             if ssl_certificate is not None and self.jtwc_source in ['jtwc', 'ucar']:
-                import ssl
-                ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-                ssl_context.load_verify_locations(cafile=ssl_certificate)
-                if requests.get(url, verify=ssl_context).status_code != 200:
+                if requests.get(url, verify=ssl_certificate).status_code != 200:
                     raise RuntimeError(
                         "JTWC forecast data is unavailable for this storm.")
             else:


### PR DESCRIPTION
I recently was unable to get the data to load. In the end I needed to add my SSL certification but it hit the error:
`TypeError: stat: path should be string, bytes, os.PathLike or integer, not SSLContext`

This seemed to be caused by:
```
            if ssl_certificate is not None and self.jtwc_source in ['jtwc', 'ucar']:
                import ssl
                ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
                ssl_context.load_verify_locations(cafile=ssl_certificate)
                if requests.get(url, verify=ssl_context).status_code != 200:
                    raise RuntimeError(
                        "JTWC forecast data is unavailable for this storm.")
```

Specifically that `verify` from requests expects a path or string
https://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification.

I was able to fix the issue by changing `verify=ssl_context` to `verify=ssl_certificate`.

This then led to what seemed to unneeded code, which I removed:
```
                import ssl
                ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
                ssl_context.load_verify_locations(cafile=ssl_certificate)
```

For reference, I am on Ubuntu 24.04 using Python3.12. I also tested on Python3.11

Please help me to check the above that it will work correctly for others as well.