### PR TITLE
Replace pkg_resources version fallback

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     networkx>=2.0.0
     requests>=2.22.0
     pyshp>=2.1
+    importlib-metadata; python_version < "3.8"
 
 [options.packages.find]
 where = src

--- a/src/tropycal/_version.py
+++ b/src/tropycal/_version.py
@@ -8,5 +8,8 @@ def get_version():
         return get_version(root='..', relative_to=__file__,
                            version_scheme='post-release', local_scheme='dirty-tag')
     except (ImportError, LookupError):
-        from pkg_resources import get_distribution
-        return get_distribution(__package__).version
+        try:
+            from importlib.metadata import version as distribution_version
+        except ImportError:
+            from importlib_metadata import version as distribution_version
+        return distribution_version(__package__)

--- a/src/tropycal/plot/plot.py
+++ b/src/tropycal/plot/plot.py
@@ -1,6 +1,5 @@
 import numpy as np
 import warnings
-import pkg_resources
 from datetime import datetime as dt, timedelta
 
 from ..utils import *


### PR DESCRIPTION
## Summary

- replace the installed-version fallback with the standard-library importlib.metadata API, using the importlib-metadata backport on Python <3.8
- remove the remaining unused pkg_resources import from the plotting module

## Validation

- `git diff --check HEAD~1..HEAD`
- Not run locally

Refs #245