### PR TITLE
Fix IBTrACS jtwc_neumann parsing against v04r01 column layout

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tropycal
-version = 1.5
+version = 1.5.1
 description = Package for retrieving and analyzing tropical cyclone data
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/tropycal/tracks/dataset.py
+++ b/src/tropycal/tracks/dataset.py
@@ -764,6 +764,18 @@ class TrackDataset:
         # Initialize empty dict for neumann data
         neumann = {}
 
+        # Resolve Neumann reanalysis column indices by header name, as the
+        # IBTrACS column layout varies between versions (e.g., v04r01 moved
+        # the NEUMANN_* columns). Fall back to the pre-v04r01 positions if
+        # the header row is unavailable.
+        neumann_idx = list(range(141, 146))
+        if self.neumann:
+            header = content[0]
+            neumann_cols = ['NEUMANN_LAT', 'NEUMANN_LON',
+                            'NEUMANN_CLASS', 'NEUMANN_WIND', 'NEUMANN_PRES']
+            if all(col in header for col in neumann_cols):
+                neumann_idx = [header.index(col) for col in neumann_cols]
+
         # ibtracs ID to jtwc ID mapping
         map_duplicate_id = {}
         map_all_id = {}
@@ -907,9 +919,9 @@ class TrackDataset:
                             self.data['IO022018']['name'] = 'MEKUNU'
 
             # Get neumann data for storms containing it
-            if self.neumann:
-                neumann_lat, neumann_lon, neumann_type, neumann_vmax, neumann_mslp = line[
-                    141:146]
+            if self.neumann and max(neumann_idx) < len(line):
+                neumann_lat, neumann_lon, neumann_type, neumann_vmax, neumann_mslp = [
+                    line[i] for i in neumann_idx]
                 if neumann_lat != "" and neumann_lon != "":
 
                     # Add storm to list of keys
@@ -988,7 +1000,7 @@ class TrackDataset:
             else:
                 if lat == "" or lon == "":
                     continue
-                if usa_agency == "" and track_type != "PROVISIONAL":
+                if usa_agency == "" and not track_type.endswith("PROVISIONAL"):
                     continue
 
             # map JTWC to ibtracs ID (for neumann replacement)


### PR DESCRIPTION
The Neumann reanalysis branch of the IBTrACS reader unpacked columns via a hardcoded slice (line[141:146]) written for an older file layout. In the current v04r01 files those positions hold DS824/TD9636 legacy dataset columns, so the presence gate fired for most 1960s-1980s Southern Hemisphere storms and replaced their JTWC tracks with garbage (TD9636_STAGE read as wind, TD9636_WIND read as pressure - e.g. Cyclone Tracy 1974 returned 5 kt / 10 hPa). The NEUMANN_* columns now live at indices 152-156.

Resolve the Neumann columns by header name from the file's header row, falling back to the historical slice only if the NEUMANN_* names are absent, and guard against short rows. Verified against the live NCEI v04r01 SI file: Tracy now returns 110 kt / 950 hPa in jtwc_neumann mode while jtwc mode is unchanged (65 kt).

Also accept the US-PROVISIONAL track_type NCEI now uses for recent seasons (in addition to PROVISIONAL) in the jtwc row-acceptance check, so provisional rows with blank USA_AGENCY are no longer dropped.

Bump version to 1.5.1.


Claude-Session: https://claude.ai/code/session_01EsLrEydnfUDGT2upzrPo7e